### PR TITLE
Using different matrix to take co-boundry and fixing bug in inflation…

### DIFF
--- a/ramanujan/pcf/pcf_from_matrix.py
+++ b/ramanujan/pcf/pcf_from_matrix.py
@@ -13,16 +13,24 @@ class PCFFromMatrix:
 
         `converted = PCFFromMatrix(Matrix, deflate_all=True)`
         """
-        U = Matrix([[matrix[1, 0], -matrix[0, 0]], [0, 1]])
-        Uinv = Matrix([[1, matrix[0, 0]], [0, matrix[1, 0]]])
-        commutated = U * matrix * Uinv({n: n + 1})
+        U = Matrix([
+            [1, matrix[0, 0]], 
+            [0, matrix[1, 0]]
+            ])
+        Uinv = Matrix([
+            [1, -matrix[0, 0]/matrix[1, 0]], 
+            [0, 1/matrix[1, 0]]
+            ])
+
+        commutated = Uinv * matrix * U({n: n + 1})
         normalized = (commutated / commutated[1, 0]).simplify()
         if not (normalized[0, 0] == 0 and normalized[1, 0] == 1):
             raise ValueError(
                 f"An error has occured when converting matrix {matrix} into a pcf"
             )
+
         pcf = PCF(normalized[1, 1], normalized[0, 1])
-        pcf.inflate(matrix[1, 0])
+        pcf = pcf.inflate(matrix[1, 0])
         if deflate_all:
             pcf = pcf.deflate_all()
 


### PR DESCRIPTION
Addressing issue 26 "Errors in converting CMF trajectories to PCFs"
After consulting with Ofir, now using a different matrix to take the co-boundary. 
Also fixing a bug in the inflation process - the return value of `pcf.inflate` was not stored back to `pcf`, leaving it at it's non-inflated form.