### PR TITLE
Unnormalize depth in CMF.walk

### DIFF
--- a/ramanujantools/cmf/cmf.py
+++ b/ramanujantools/cmf/cmf.py
@@ -270,8 +270,7 @@ class CMF:
         trajectory_matrix = self.trajectory_matrix(
             trajectory, start or self.default_origin()
         )
-        actual_iterations = [i // sum(trajectory.values()) for i in iterations]
-        return trajectory_matrix.walk({n: 1}, actual_iterations, {n: 1})
+        return trajectory_matrix.walk({n: 1}, iterations, {n: 1})
 
     @multimethod
     def walk(  # noqa: F811

--- a/ramanujantools/cmf/cmf_test.py
+++ b/ramanujantools/cmf/cmf_test.py
@@ -98,14 +98,14 @@ def test_walk_axis():
 def test_walk_diagonal():
     cmf = known_cmfs.e()
     Mxy = cmf.trajectory_matrix({x: 1, y: 1}, {x: 1, y: 1})
-    assert cmf.walk({x: 1, y: 1}, 17) == Mxy.walk({n: 1}, 17 // 2, {n: 1})
+    assert cmf.walk({x: 1, y: 1}, 9) == Mxy.walk({n: 1}, 9, {n: 1})
 
 
 def test_limit_diagonal():
     cmf = known_cmfs.e()
     Mxy = cmf.trajectory_matrix({x: 1, y: 1})
     assert cmf.limit({x: 1, y: 1}, 17) == Limit(
-        Mxy.walk({x: 1, y: 1}, 17 // 2, {x: 1, y: 1})
+        Mxy.walk({x: 1, y: 1}, 17, {x: 1, y: 1})
     )
 
 


### PR DESCRIPTION
Removed normalization of depth by trajectory size in CMF.walk method.