### PR TITLE
Bugfix/rational matrices fast subs

### DIFF
--- a/ramanujantools/cmf/cmf.py
+++ b/ramanujantools/cmf/cmf.py
@@ -317,11 +317,8 @@ class CMF:
         return self.limit(trajectory, [iterations], start)[0]
 
     def delta(
-            self,
-            trajectory: dict,
-            depth: int,
-            start: dict = None,
-            limit: float = None):
+        self, trajectory: dict, depth: int, start: dict = None, limit: float = None
+    ):
         r"""
         Calculates the irrationality measure $\delta$ defined, as:
         $|\frac{p_n}{q_n} - L| = \frac{1}{q_n}^{1+\delta}$
@@ -349,11 +346,8 @@ class CMF:
         return approximants[0].delta(limit)
 
     def delta_sequence(
-            self,
-            trajectory: dict,
-            depth: int,
-            start: dict = None,
-            limit: float = None):
+        self, trajectory: dict, depth: int, start: dict = None, limit: float = None
+    ):
         r"""
         Add description here
         """

--- a/ramanujantools/limit.py
+++ b/ramanujantools/limit.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import List
-import math
 
+import sympy as sp
 from mpmath import mp
 
 from ramanujantools import Matrix
@@ -95,7 +95,9 @@ class Limit(Matrix):
         Returns:
             a list of the form [p, q], representing the rational number.
         """
-        return [self[p_indices[0], p_indices[1]], self[q_indices[0], q_indices[1]]]
+        p = sp.Rational(self[p_indices[0], p_indices[1]])
+        q = sp.Rational(self[q_indices[0], q_indices[1]])
+        return [p.numerator * q.denominator, p.denominator * q.numerator]
 
     def as_float(self, p_indices=[0, -1], q_indices=[1, -1]) -> mp.mpf:
         r"""
@@ -131,7 +133,7 @@ class Limit(Matrix):
         """
         self.increase_precision(p_indices, q_indices)
         p, q = self.as_rational(p_indices, q_indices)
-        gcd = math.gcd(p, q)
+        gcd = sp.gcd(p, q)
         reduced_q = mp.fabs(q // gcd)
         if reduced_q == 1:
             return mp.mpf("inf")

--- a/ramanujantools/limit.py
+++ b/ramanujantools/limit.py
@@ -97,7 +97,10 @@ class Limit(Matrix):
         """
         p = sp.Rational(self[p_indices[0], p_indices[1]])
         q = sp.Rational(self[q_indices[0], q_indices[1]])
-        return [p.numerator * q.denominator, p.denominator * q.numerator]
+        return [
+            sp.Integer(p.numerator * q.denominator),
+            sp.Integer(p.denominator * q.numerator),
+        ]
 
     def as_float(self, p_indices=[0, -1], q_indices=[1, -1]) -> mp.mpf:
         r"""

--- a/ramanujantools/matrix.py
+++ b/ramanujantools/matrix.py
@@ -132,7 +132,7 @@ class Matrix(sp.Matrix):
     @lru_cache()
     def inverse(self) -> Matrix:
         """
-        Inverses the matrix.
+        Inverts the matrix.
         """
         return self.inv()
 

--- a/ramanujantools/matrix.py
+++ b/ramanujantools/matrix.py
@@ -19,7 +19,11 @@ class Matrix(sp.Matrix):
         return repr(self)
 
     def __eq__(self, other: Matrix) -> bool:
-        return all(sp.simplify(cell) == 0 for cell in self - other)
+        return (
+            self.rows == other.rows
+            and self.cols == other.cols
+            and all(sp.simplify(cell) == 0 for cell in self - other)
+        )
 
     def __hash__(self) -> int:
         return hash(frozenset(self))

--- a/ramanujantools/matrix.py
+++ b/ramanujantools/matrix.py
@@ -48,9 +48,12 @@ class Matrix(sp.Matrix):
         """
         Returns true iff the all substitutions are numerical and we can can call `numerical_subs` instead of `xreplace`.
         """
-        return not (
-            len(substitutions) < len(self.free_symbols)
-            or any(isinstance(element, sp.Expr) for element in substitutions.values())
+        return (
+            self.is_polynomial()
+            and len(substitutions) == len(self.free_symbols)
+            and not (
+                any(isinstance(element, sp.Expr) for element in substitutions.values())
+            )
         )
 
     def numerical_subs(self, substitutions: Dict) -> Matrix:
@@ -58,7 +61,7 @@ class Matrix(sp.Matrix):
         An optimized version of `subs` for the case where all free_symbols are present in the substitutions dict,
         and all requested values are numerical (i.e not sympy expressions of any sort)
         """
-        fast_subs = self.create_fast_subs(self)
+        fast_subs = Matrix.create_fast_subs(self)
         return fast_subs(substitutions)
 
     @staticmethod
@@ -93,6 +96,10 @@ class Matrix(sp.Matrix):
         """
         divisors = [cell.cancel().as_numer_denom()[1] for cell in self]
         return sp.lcm(divisors)
+
+    @lru_cache()
+    def is_polynomial(self) -> bool:
+        return self.denominator_lcm() == 1
 
     def as_polynomial(self) -> Matrix:
         """

--- a/ramanujantools/matrix.py
+++ b/ramanujantools/matrix.py
@@ -94,6 +94,7 @@ class Matrix(sp.Matrix):
         """
         return self.rows == self.cols
 
+    @lru_cache()
     def denominator_lcm(self) -> sp.Expr:
         """
         Returns the lcm of all denominators
@@ -101,7 +102,6 @@ class Matrix(sp.Matrix):
         divisors = [cell.cancel().as_numer_denom()[1] for cell in self]
         return sp.lcm(divisors)
 
-    @lru_cache()
     def is_polynomial(self) -> bool:
         return self.denominator_lcm() == 1
 
@@ -111,6 +111,7 @@ class Matrix(sp.Matrix):
         """
         return (self * self.denominator_lcm()).simplify()
 
+    @lru_cache()
     def gcd(self) -> sp.Rational:
         """
         Returns the rational gcd of the matrix, which could also be parameteric.
@@ -128,6 +129,7 @@ class Matrix(sp.Matrix):
         m = self.simplify()
         return (m / m.gcd()).simplify()
 
+    @lru_cache()
     def inverse(self) -> Matrix:
         """
         Inverses the matrix.

--- a/ramanujantools/matrix_test.py
+++ b/ramanujantools/matrix_test.py
@@ -29,8 +29,17 @@ def test_reduce():
 
 def test_can_call_numerical_subs():
     m = Matrix([[x, 1], [y, 2]])
+
+    # not enough parameters
     assert not m._can_call_numerical_subs({x: 1})
+
+    # some parameters are not integer
     assert not m._can_call_numerical_subs({x: 1, y: y})
+    assert not m._can_call_numerical_subs({x: 1, y: sp.Rational(2, 3)})
+
+    # rational matrix
+    assert not (m / x)._can_call_numerical_subs({x: 1, y: 1})
+
     assert m._can_call_numerical_subs({x: 17, y: 31})
 
 
@@ -44,7 +53,6 @@ def test_subs_degenerated():
 def test_subs_numerical():
     m = Matrix([[x, x**2], [13 + x, -x]])
     substitutions = {x: 5}
-    assert m._can_call_numerical_subs(substitutions)
     assert Matrix([[5, 25], [18, -5]]) == m.subs(substitutions)
 
 
@@ -52,6 +60,12 @@ def test_subs_symbolic():
     m = Matrix([[x, x**2, 13 + x, -x]])
     expr = y**2 + x - 3
     assert Matrix([[expr, (expr) ** 2, 13 + expr, -expr]]) == m.subs({x: expr})
+
+
+def test_subs_numerical_equivalent_to_symbolic():
+    m = Matrix([[x, x**2], [13 + x, -x]])
+    substitutions = {x: 5}
+    assert m.xreplace(substitutions) == m.numerical_subs(substitutions)
 
 
 def test_as_polynomial():


### PR DESCRIPTION
Fix bugs occured by https://github.com/RamanujanMachine/ramanujantools/pull/59, because numerical evaluation is impossible for rational matrices (as division causes floats instead of rationals).