### PR TITLE
Feature/limit without trajectory matrix

### DIFF
--- a/ramanujantools/cmf/cmf.py
+++ b/ramanujantools/cmf/cmf.py
@@ -251,7 +251,7 @@ class CMF:
     def walk(  # noqa: F811
         self,
         trajectory: dict,
-        iterations: List,
+        iterations: List[int],
         start: Union[dict, type(None)] = None,
     ) -> List[Matrix]:
         r"""
@@ -317,7 +317,7 @@ class CMF:
     def limit(
         self,
         trajectory: dict,
-        iterations: List,
+        iterations: List[int],
         start: Union[dict, type(None)] = None,
     ) -> List[Limit]:
         r"""

--- a/ramanujantools/cmf/cmf_test.py
+++ b/ramanujantools/cmf/cmf_test.py
@@ -102,7 +102,7 @@ def test_limit_diagonal():
 def test_walk_list():
     cmf = known_cmfs.e()
     trajectory = {x: 2, y: 3}
-    iterations = list(map(lambda x: x * sum(trajectory.values()), [1, 2, 3, 17, 29]))
+    iterations = [1, 2, 3, 17, 29]
     assert cmf.walk(trajectory, iterations) == [
         cmf.walk(trajectory, i) for i in iterations
     ]
@@ -164,6 +164,8 @@ def test_blind_delta_sequence_agrees_with_blind_delta():
     trajectory = {a: 1, b: 2, c: 0}
     limit = cmf.limit(trajectory, 2 * depth).as_float()
     delta_sequence = cmf.delta_sequence(trajectory, depth)
-    sequence_of_deltas = [cmf.delta(trajectory, i, limit=limit) for i in range(1, depth+1)]
+    sequence_of_deltas = [
+        cmf.delta(trajectory, i, limit=limit) for i in range(1, depth + 1)
+    ]
     assert delta_sequence == sequence_of_deltas
     assert len(delta_sequence) == depth

--- a/ramanujantools/matrix.py
+++ b/ramanujantools/matrix.py
@@ -155,7 +155,7 @@ class Matrix(sp.Matrix):
 
     @multimethod
     def walk(  # noqa: F811
-        self, trajectory: Dict, iterations: List, start: Dict
+        self, trajectory: Dict, iterations: list[int], start: Dict
     ) -> List[Matrix]:
         r"""
         Returns the multiplication result of walking in a certain trajectory.
@@ -190,9 +190,9 @@ class Matrix(sp.Matrix):
                 f"iterations must contain only non-negative values, got {iterations}"
             )
 
+        results = []
         position = start
         matrix = Matrix.eye(self.rows)
-        results = []
         previous_depth = 0
         for depth in iterations:
             effective_depth = depth - previous_depth

--- a/ramanujantools/matrix.py
+++ b/ramanujantools/matrix.py
@@ -155,7 +155,7 @@ class Matrix(sp.Matrix):
 
     @multimethod
     def walk(  # noqa: F811
-        self, trajectory: Dict, iterations: list[int], start: Dict
+        self, trajectory: Dict, iterations: List[int], start: Dict
     ) -> List[Matrix]:
         r"""
         Returns the multiplication result of walking in a certain trajectory.

--- a/ramanujantools/matrix_test.py
+++ b/ramanujantools/matrix_test.py
@@ -148,16 +148,6 @@ def test_walk_start_multi_variable():
     assert expected == actual
 
 
-def test_walk_sequence():
-    trajectory = {x: 2, y: 3}
-    start = {x: 5, y: 7}
-    iterations = [1, 2, 3, 17, 29, 53, 99]
-    m = Matrix([[x, 3 * x + 5 * y], [y**7 + x - 3, x**5]])
-    assert m.walk(trajectory, tuple(iterations), start) == m.walk(
-        trajectory, set(iterations), start
-    )
-
-
 def test_walk_axis():
     m = Matrix([[x, 3 * x + 5 * y], [y**7 + x - 3, x**5]])
     assert simplify(m.walk({x: 1, y: 0}, 3, {x: 1, y: 1})) == simplify(


### PR DESCRIPTION
Implemented the CMF.walk method (and consecutively the limit method) without using trajectory matrix, which increases performance especially in cases where the trajectory contains numbers >= 2.
