### PR TITLE
Feature/as latex

### DIFF
--- a/ramanujantools/matrix.py
+++ b/ramanujantools/matrix.py
@@ -33,6 +33,21 @@ class Matrix(sp.Matrix):
         Substitutes symbols in the matrix, in a more math-like syntax.
         """
         return self.subs(substitutions)
+    
+    def as_latex(self, print_bool: bool = True) -> None:
+        """
+        Prints the matrix as a latex string.
+        Args:
+            print_bool: if `True`, prints the latex string to the console (set to False for testing).
+        Prints:
+            The latex string (pmatrix format) of the matrix.
+        Returns:
+            The latex string (pmatrix format) of the matrix (python representation).
+        """
+        result = sp.latex(self).replace("\\left[", "").replace("\\right]", "").replace("matrix", "pmatrix")
+        if print_bool:
+            print(result)
+        return result
 
     def subs(self, substitutions: Dict) -> Matrix:
         """

--- a/ramanujantools/matrix.py
+++ b/ramanujantools/matrix.py
@@ -34,20 +34,12 @@ class Matrix(sp.Matrix):
         """
         return self.subs(substitutions)
     
-    def as_latex(self, print_bool: bool = True) -> None:
+    def as_latex(self) -> str:
         """
-        Prints the matrix as a latex string.
-        Args:
-            print_bool: if `True`, prints the latex string to the console (set to False for testing).
-        Prints:
-            The latex string (pmatrix format) of the matrix.
-        Returns:
-            The latex string (pmatrix format) of the matrix (python representation).
+        Returns The latex (pmatrix) string of the matrix (python representation, e.g. '\' is '\\').
+        Note: result should be printed to obtain actual LaTex string format.
         """
-        result = sp.latex(self).replace("\\left[", "").replace("\\right]", "").replace("matrix", "pmatrix")
-        if print_bool:
-            print(result)
-        return result
+        return sp.latex(self).replace("\\left[", "").replace("\\right]", "").replace("matrix", "pmatrix")
 
     def subs(self, substitutions: Dict) -> Matrix:
         """

--- a/ramanujantools/matrix_test.py
+++ b/ramanujantools/matrix_test.py
@@ -190,4 +190,4 @@ def test_walk_different_start():
 
 def test_as_latex():
     m = Matrix([[x, 3 * x + 5 * y], [y**7 + x - 3, x**5]])
-    assert m.as_latex(print_bool=False) == '\\begin{pmatrix}x & 3 x + 5 y\\\\x + y^{7} - 3 & x^{5}\\end{pmatrix}'
+    assert '\\begin{pmatrix}x & 3 x + 5 y\\\\x + y^{7} - 3 & x^{5}\\end{pmatrix}' == m.as_latex()

--- a/ramanujantools/matrix_test.py
+++ b/ramanujantools/matrix_test.py
@@ -187,3 +187,7 @@ def test_walk_different_start():
     assert simplify(m.walk({x: 3, y: 2}, 3, {x: 5, y: 7})) == simplify(
         m({x: 5, y: 7}) * m({x: 8, y: 9}) * m({x: 11, y: 11})
     )
+
+def test_as_latex():
+    m = Matrix([[x, 3 * x + 5 * y], [y**7 + x - 3, x**5]])
+    assert m.as_latex(print_bool=False) == '\\begin{pmatrix}x & 3 x + 5 y\\\\x + y^{7} - 3 & x^{5}\\end{pmatrix}'

--- a/ramanujantools/pcf/pcf.py
+++ b/ramanujantools/pcf/pcf.py
@@ -112,34 +112,42 @@ class PCF:
     def __repr__(self):
         return f"PCF({self.a_n}, {self.b_n})"
     
-    def as_latex(self, depth: int = 3, start: int = 1, generic: bool = False, print_bool: bool = True):
+    @multimethod
+    def as_latex(self, depth: int = 3, start: int = 1) -> str:
         """
-        Prints as a continued fraction in LaTeX format.
+        Returns the continued fraction as a string in LaTeX format.
         Note: result should be printed to obtain actual LaTex string format.
 
         Args:
-            depth: The depth to display up to.
+            depth: The index to display up to.
             start: The index from which to display.
-            generic: Whether to use generic symbols like a_n, b_n or the actual values.
-        Prints:
-            The LaTeX string for the continued fraction.
         Returns:
-            The LaTeX string for the continued fraction (python representation).
+            The LaTeX string for the continued fraction (python representation, i.e. '\' is '\\').
         """
-        if generic == True:
-            # Use generic symbols
-            if start != 1:
-                result = rf'\cfrac{{b_{start}}}{{{generic_recursive_fraction(start, depth)}}}'
-            else:
-                result = rf'a_0 + \cfrac{{b_1}}{{{generic_recursive_fraction(start, depth)}}}'
+        if start != 1:
+            result = rf'\cfrac{{{self.b_n.subs(n, start)}}}{{{recursive_fraction(start, depth, self.a_n, self.b_n)}}}'
         else:
-            if start != 1:
-                result = rf'\cfrac{{{self.b_n.subs(n, start)}}}{{{recursive_fraction(start, depth, self.a_n, self.b_n)}}}'
-            else:
-                result = rf'{self.a_n.subs(n, 0)} + \cfrac{{{self.b_n.subs(n, 1)}}}{{{recursive_fraction(start, depth, self.a_n, self.b_n)}}}'
-        if print_bool:
-            print(python_to_latex(result))
-        return result
+            result = rf'{self.a_n.subs(n, 0)} + \cfrac{{{self.b_n.subs(n, 1)}}}{{{recursive_fraction(start, depth, self.a_n, self.b_n)}}}'
+        return python_to_latex(result)
+    
+    @multimethod
+    @staticmethod
+    def as_latex(depth: int = 3, start: int = 1) -> str:
+        """
+        Returns a generic continued fraction as a string in LaTeX format,
+        with symbols $a_n$ and $b_n$ as the partial denominators and numerators, respectively.
+        Args:
+            depth: The index to display up to.
+            start: The index from which to display.
+        Returns:
+            The LaTeX string for the continued fraction (python representation, i.e. '\' is '\\').
+            e.g. 'a_0 + \\cfrac{b_1}{a_1 + \\cfrac{b_2}{a_2 + \\cfrac{b_3}{\\ddots + \\cfrac{b_n}{a_n + \\ddots}}}}'.
+        """
+        if start != 1:
+            result = rf'\cfrac{{b_{start}}}{{{generic_recursive_fraction(start, depth)}}}'
+        else:
+            result = rf'a_0 + \cfrac{{b_1}}{{{generic_recursive_fraction(start, depth)}}}'
+        return python_to_latex(result)
     
     def degree(self):
         """

--- a/ramanujantools/pcf/pcf_test.py
+++ b/ramanujantools/pcf/pcf_test.py
@@ -138,15 +138,33 @@ def test_blind_delta_sequence_agrees_with_blind_delta():
     assert expected_deltas == actual_values
 
 
-def test_as_latex():
+def test_as_latex_not_generic():
     pcf = PCF(1 + n - n**2, 3 - n**9)
-    expected = (
+
+    expected_depth5_start1 = (
         '1 + \\cfrac{2}{1 + \\cfrac{-509}{-1 + \\cfrac{-19680}'
         '{-5 + \\cfrac{-262141}{-11 + \\cfrac{-1953122}'
-        '{\\ddots + \\cfrac{3 - n**9}{-n**2 + n + 1 + \\ddots}}}}}}')
-    expected_generic = (
-        'a_0 + \\cfrac{b_1}{a_1 + \\cfrac{b_2}{a_2 + '
-        '\\cfrac{b_3}{a_3 + \\cfrac{b_4}{a_4 + '
-        '\\cfrac{b_5}{\\ddots + \\cfrac{b_n}{a_n + \\ddots}}}}}}')
-    assert pcf.as_latex(depth=5, print_bool=False) == expected
-    assert pcf.as_latex(depth=5, generic=True, print_bool=False) == expected_generic
+        '{\\ddots + \\cfrac{3 - n^9}{-n^2 + n + 1 + \\ddots}}}}}}')
+    expected_depth7_start3 = (
+        '\\cfrac{-19680}{-5 + \\cfrac{-262141}{-11 + \\cfrac{-1953122}'
+        '{-19 + \\cfrac{-10077693}{-29 + \\cfrac{-40353604}'
+        '{\\ddots + \\cfrac{3 - n^9}{-n^2 + n + 1 + \\ddots}}}}}}')
+    
+    assert expected_depth5_start1 == pcf.as_latex(depth=5, start=1)
+    assert expected_depth7_start3 == pcf.as_latex(depth=7, start=3)
+
+
+def test_as_latex_generic():
+
+    expected_depth5_start1 = (
+        'a_0 + \\cfrac{b_1}{a_1 + \\cfrac{b_2}{a_2 + \\cfrac{b_3}'
+        '{a_3 + \\cfrac{b_4}{a_4 + \\cfrac{b_5}'
+        '{\\ddots + \\cfrac{b_n}{a_n + \\ddots}}}}}}')
+    expected_depth7_start3 = (
+        '\\cfrac{b_3}{a_3 + \\cfrac{b_4}'
+        '{a_4 + \\cfrac{b_5}{a_5 + \\cfrac{b_6}{a_6 + \\cfrac{b_7}'
+        '{\\ddots + \\cfrac{b_n}{a_n + \\ddots}}}}}}')
+    
+    assert expected_depth5_start1 == PCF.as_latex(depth=5, start=1)
+    assert expected_depth7_start3 == PCF.as_latex(depth=7, start=3)
+

--- a/ramanujantools/pcf/pcf_test.py
+++ b/ramanujantools/pcf/pcf_test.py
@@ -136,3 +136,17 @@ def test_blind_delta_sequence_agrees_with_blind_delta():
         expected_deltas.append(pcf.delta(dep, limit))
 
     assert expected_deltas == actual_values
+
+
+def test_as_latex():
+    pcf = PCF(1 + n - n**2, 3 - n**9)
+    expected = (
+        '1 + \\cfrac{2}{1 + \\cfrac{-509}{-1 + \\cfrac{-19680}'
+        '{-5 + \\cfrac{-262141}{-11 + \\cfrac{-1953122}'
+        '{\\ddots + \\cfrac{3 - n**9}{-n**2 + n + 1 + \\ddots}}}}}}')
+    expected_generic = (
+        'a_0 + \\cfrac{b_1}{a_1 + \\cfrac{b_2}{a_2 + '
+        '\\cfrac{b_3}{a_3 + \\cfrac{b_4}{a_4 + '
+        '\\cfrac{b_5}{\\ddots + \\cfrac{b_n}{a_n + \\ddots}}}}}}')
+    assert pcf.as_latex(depth=5, print_bool=False) == expected
+    assert pcf.as_latex(depth=5, generic=True, print_bool=False) == expected_generic


### PR DESCRIPTION
Allows for easy export of PCFs and Matrices to latex format:
a_0 + \cfrac{b_1}{a_1 + \cfrac{b_2}{a_2 + \cfrac{b_3}{\ddots + \cfrac{b_n}{a_n + \ddots}}}}
and e.g.
\begin{pmatrix} 0 & \frac{n^{2}}{n + 1} \\\\1 & 8\end{pmatrix}