### PR TITLE
Feature/advanced limit

### DIFF
--- a/ramanujantools/cmf/cmf.py
+++ b/ramanujantools/cmf/cmf.py
@@ -342,9 +342,11 @@ class CMF:
             The limit of the walk multiplication as defined above.
             If `iterations` is a list, returns a list of limits.
         """
-        return list(
-            map(lambda matrix: Limit(matrix), self.walk(trajectory, iterations, start))
-        )
+
+        def walk_function(iterations):
+            return self.walk(trajectory, iterations, start)
+
+        return Limit.walk_to_limit(iterations, walk_function)
 
     @multimethod
     def limit(  # noqa: F811

--- a/ramanujantools/cmf/cmf.py
+++ b/ramanujantools/cmf/cmf.py
@@ -358,7 +358,13 @@ class CMF:
         return self.limit(trajectory, [iterations], start)[0]
 
     def delta(
-        self, trajectory: dict, depth: int, start: dict = None, limit: float = None
+        self,
+        trajectory: dict,
+        depth: int,
+        start: dict = None,
+        limit: float = None,
+        p_vectors: Union[List[Matrix], type(None)] = None,
+        q_vectors: Union[List[Matrix], type(None)] = None,
     ):
         r"""
         Calculates the irrationality measure $\delta$ defined, as:
@@ -373,7 +379,10 @@ class CMF:
             trajectory: the trajectory of the walk.
             depth: $n$, is the number of trajectory matrices multiplied.
                 The $\ell_1$ distance walked from the start point is `depth * sum(trajectory.values())`.
+            start: the starting point of the walk operation.
             limit: $L$
+            p_vectors: numerator extraction vectors for delta
+            q_vectors: denominator extraction vectors for delta
         Returns:
             the delta value as defined above.
         """
@@ -384,13 +393,30 @@ class CMF:
             approximants = approximants[:-1]
         else:
             approximants = self.limit(trajectory, [depth], start)
-        return approximants[0].delta(limit)
+        return approximants[0].delta(limit, p_vectors, q_vectors)
 
     def delta_sequence(
-        self, trajectory: dict, depth: int, start: dict = None, limit: float = None
+        self,
+        trajectory: dict,
+        depth: int,
+        start: dict = None,
+        limit: float = None,
+        p_vectors: Union[List[Matrix], type(None)] = None,
+        q_vectors: Union[List[Matrix], type(None)] = None,
     ):
         r"""
-        Add description here
+        Calculates delta values sequentially up to `depth`.
+
+        Args:
+            trajectory: the trajectory of the walk.
+            depth: $n$, is the number of trajectory matrices multiplied.
+                The $\ell_1$ distance walked from the start point is `depth * sum(trajectory.values())`.
+            start: the starting point of the walk operation.
+            limit: $L$
+            p_vectors: numerator extraction vectors for delta
+            q_vectors: denominator extraction vectors for delta
+        Returns:
+            the delta value as defined above.
         """
         depths = list(range(1, depth + 1))
         if limit is None:
@@ -400,4 +426,7 @@ class CMF:
             approximants = approximants[:-1]
         else:
             approximants = self.limit(trajectory, depths, start)
-        return [approximant.delta(limit) for approximant in approximants]
+        return [
+            approximant.delta(limit, p_vectors, q_vectors)
+            for approximant in approximants
+        ]

--- a/ramanujantools/cmf/cmf.py
+++ b/ramanujantools/cmf/cmf.py
@@ -171,7 +171,9 @@ class CMF:
         Returns a new CMF with simplified Mx and My
         """
         return CMF(
-            matrices={symbol: simplify(matrix) for symbol, matrix in self.matrices}
+            matrices={
+                symbol: simplify(matrix) for symbol, matrix in self.matrices.items()
+            }
         )
 
     def default_origin(self):

--- a/ramanujantools/cmf/cmf_test.py
+++ b/ramanujantools/cmf/cmf_test.py
@@ -1,7 +1,7 @@
 from pytest import raises
 from sympy.abc import a, b, c, x, y, n
 
-from ramanujantools import Limit, Matrix, simplify
+from ramanujantools import Matrix, simplify
 from ramanujantools.cmf import CMF, known_cmfs
 
 
@@ -94,9 +94,7 @@ def test_walk_diagonal():
 def test_limit_diagonal():
     cmf = known_cmfs.e()
     Mxy = cmf.trajectory_matrix({x: 1, y: 1})
-    assert cmf.limit({x: 1, y: 1}, 17) == Limit(
-        Mxy.walk({x: 1, y: 1}, 17, {x: 1, y: 1})
-    )
+    assert cmf.limit({x: 1, y: 1}, 17) == Mxy.limit({x: 1, y: 1}, 17, {x: 1, y: 1})
 
 
 def test_walk_list():
@@ -151,11 +149,9 @@ def test_delta_correctness():
     cmf = known_cmfs.hypergeometric_derived_2F1()
     depth = 100
     trajectory = {a: 1, b: 0, c: 1}
-    approximant_matrix, limit_matrix = cmf.walk(trajectory, [depth, 2 * depth])
-    approximant_matrix = Limit(approximant_matrix)
-    limit = Limit(limit_matrix).as_float()
-    assert cmf.delta(trajectory, depth) == approximant_matrix.delta(limit)
-    assert cmf.delta(trajectory, depth, limit=limit) == approximant_matrix.delta(limit)
+    l1, l2 = cmf.limit(trajectory, [depth, 2 * depth])
+    assert cmf.delta(trajectory, depth) == l1.delta(l2.as_float())
+    assert cmf.delta(trajectory, depth, limit=l2.as_float()) == l1.delta(l2.as_float())
 
 
 def test_blind_delta_sequence_agrees_with_blind_delta():

--- a/ramanujantools/limit.py
+++ b/ramanujantools/limit.py
@@ -37,7 +37,7 @@ class Limit:
     Uses the last step to extract constants, and the previous one to determine precision.
     """
 
-    def __init__(self, current: Matrix, previous: Matrix = None):
+    def __init__(self, current: Matrix, previous: Matrix):
         self.current = current
         self.previous = previous
 

--- a/ramanujantools/limit.py
+++ b/ramanujantools/limit.py
@@ -48,12 +48,7 @@ class Limit:
         return repr(self)
 
     def __eq__(self, other: Limit) -> bool:
-        """
-        Returns true iff two limits converge to the same value.
-        """
-        p, q = self.as_rational()
-        other_p, other_q = other.as_rational()
-        return p * other_q == q * other_p
+        return self.current == other.current and self.previous == other.previous
 
     def as_rational(
         self, p_index: int = 0, q_index: int = 1, column_index: int = -1

--- a/ramanujantools/limit.py
+++ b/ramanujantools/limit.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import List
+from typing import List, Callable
 
 import sympy as sp
 from mpmath import mp
@@ -49,6 +49,27 @@ class Limit:
 
     def __eq__(self, other: Limit) -> bool:
         return self.current == other.current and self.previous == other.previous
+
+    @staticmethod
+    def walk_to_limit(
+        iterations: List[int], walk_function: Callable[List[int], List[Limit]]
+    ) -> List[Limit]:
+        previous_values = [depth - 1 for depth in iterations]
+        walk_iterations = sorted(list(set(iterations + previous_values)))
+        walk_matrices = walk_function(walk_iterations)
+
+        current_index = 0
+        limits = []
+        for depth in iterations:
+            while depth != walk_iterations[current_index]:
+                current_index += 1
+            limits.append(
+                Limit(
+                    walk_matrices[current_index],
+                    walk_matrices[current_index - 1],
+                )
+            )
+        return limits
 
     def as_rational(
         self, p_index: int = 0, q_index: int = 1, column_index: int = -1

--- a/ramanujantools/limit.py
+++ b/ramanujantools/limit.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import List, Callable
+from typing import List, Callable, Union
 
 import sympy as sp
 from mpmath import mp
@@ -50,6 +50,9 @@ class Limit:
     def __eq__(self, other: Limit) -> bool:
         return self.current == other.current and self.previous == other.previous
 
+    def N(self) -> int:
+        return self.current.rows
+
     @staticmethod
     def walk_to_limit(
         iterations: List[int], walk_function: Callable[List[int], List[Limit]]
@@ -72,28 +75,51 @@ class Limit:
         return limits
 
     def as_rational(
-        self, p_index: int = 0, q_index: int = 1, column_index: int = -1
+        self,
+        p_vectors: Union[List[Matrix], type(None)] = None,
+        q_vectors: Union[List[Matrix], type(None)] = None,
+        previous=False,
     ) -> List:
         r"""
         Returns the limit as a rational number $\frac{p}{q}$.
 
+        The numbers p and q are extracted using matrix multiplication.
+        For each number, a row vector `v1` and a column vector `v2` are received.
+        We then extract a number using `v1 * M * v2`, where M is the limit matrix.
+
         Researcher's note: rational representation of the limit is so far only well-defined for 2x2 matrices,
         and we are still looking for a generalization of this representation for NxN matrices.
         Args:
-            p_index : The row index of the numerator $p$
-            q_index: The row index of the denominator $q$
-            column_index: The column index of both $p, q$.
+            p_vectors: The extraction vectors for the numerator $p$.
+            q_vectors: The extraction vectors for the denominator $q$.
+            previous: Will use $M$ = `self.previous` if True, else `self.current`. False by default.
         Returns:
             A list of the form [p, q], representing the rational number.
         """
-        p = sp.Rational(self.current[p_index, column_index])
-        q = sp.Rational(self.current[q_index, column_index])
+        p_vectors = p_vectors or [
+            Matrix.e(self.N(), 0, column=False),
+            Matrix.e(self.N(), self.N() - 1, column=True),
+        ]
+
+        q_vectors = q_vectors or [
+            Matrix.e(self.N(), 1, column=False),
+            Matrix.e(self.N(), self.N() - 1, column=True),
+        ]
+
+        matrix = self.previous if previous else self.current
+        p = sp.Rational((p_vectors[0] * matrix * p_vectors[1])[0])
+        q = sp.Rational((q_vectors[0] * matrix * q_vectors[1])[0])
         return [
             sp.Integer(p.numerator * q.denominator),
             sp.Integer(p.denominator * q.numerator),
         ]
 
-    def precision(self, p_index=0, q_index=1, base: int = 10) -> int:
+    def precision(
+        self,
+        p_vectors: Union[List[Matrix], type(None)] = None,
+        q_vectors: Union[List[Matrix], type(None)] = None,
+        base: int = 10,
+    ) -> int:
         """
         Returns the error in 'digits' for the PCF convergence.
 
@@ -101,8 +127,8 @@ class Limit:
             base: The numerical base in which to return the precision (by default 10)
         """
         try:
-            p1, q1 = self.as_rational(p_index, q_index)
-            p2, q2 = self.as_rational(p_index, q_index, column_index=-2)
+            p1, q1 = self.as_rational(p_vectors, q_vectors)
+            p2, q2 = self.as_rational(p_vectors, q_vectors, previous=True)
             numerator = p1 * q2 - q1 * p2
             denominator = q1 * q2
             # extracting real because sometimes log returns a complex with tiny imaginary type due to precision
@@ -113,39 +139,56 @@ class Limit:
         except (ZeroDivisionError, ValueError):
             return 0
 
-    def increase_precision(self, p_index: int = 0, q_index: int = 1) -> int:
+    def increase_precision(
+        self,
+        p_vectors: Union[List[Matrix], type(None)] = None,
+        q_vectors: Union[List[Matrix], type(None)] = None,
+    ) -> int:
         """
         Increases the global mpmath precision to the lever required to handle this limit.
         Returns the current precision after the increase.
         """
         requested_precision = (
-            self.precision(p_index, q_index) * 1.1
+            self.precision(p_vectors, q_vectors) * 1.1
         )  # Taking 10% digits buffer
         mp.dps = max(mp.dps, requested_precision)
         return mp.dps
 
-    def as_float(self, p_index: int = 0, q_index: int = 1) -> mp.mpf:
+    def as_float(
+        self,
+        p_vectors: Union[List[Matrix], type(None)] = None,
+        q_vectors: Union[List[Matrix], type(None)] = None,
+    ) -> mp.mpf:
         r"""
         Returns the limit as a floating point number f, such that $m \cdot v = f$, where `m=self` and `v=vector`.
 
         This function increases the global mpmath precision if needed.
         """
-        self.increase_precision(p_index, q_index)
-        p, q = self.as_rational(p_index, q_index)
+        self.increase_precision(p_vectors, q_vectors)
+        p, q = self.as_rational(p_vectors, q_vectors)
         return mp.mpf(p) / mp.mpf(q)
 
-    def as_rounded_number(self, p_index: int = 0, q_index: int = 1) -> str:
+    def as_rounded_number(
+        self,
+        p_vectors: Union[List[Matrix], type(None)] = None,
+        q_vectors: Union[List[Matrix], type(None)] = None,
+    ) -> str:
         """
         Same as `as_float`, but also rounds the result to the shortest number possible within the error range.
 
         This function increases the global mpmath precision if needed.
         """
         return most_round_in_range(
-            self.as_float(p_index, q_index),
-            10 ** -self.precision(p_index, q_index),
+            self.as_float(p_vectors, q_vectors),
+            10 ** -self.precision(p_vectors, q_vectors),
         )
 
-    def delta(self, L: mp.mpf, p_index: int = 0, q_index: int = 1) -> mp.mpf:
+    def delta(
+        self,
+        L: mp.mpf,
+        p_vectors: Union[List[Matrix], type(None)] = None,
+        q_vectors: Union[List[Matrix], type(None)] = None,
+    ) -> mp.mpf:
         r"""
         Calculates the irrationality measure $\delta$ defined, as:
         $|\frac{p_n}{q_n} - L| = \frac{1}{q_n}^{1+\delta}$
@@ -156,8 +199,8 @@ class Limit:
         Returns:
             the delta value as defined above.
         """
-        self.increase_precision(p_index, q_index)
-        p, q = self.as_rational(p_index, q_index)
+        self.increase_precision(p_vectors, q_vectors)
+        p, q = self.as_rational(p_vectors, q_vectors)
         gcd = sp.gcd(p, q)
         reduced_q = mp.fabs(q // gcd)
         if reduced_q == 1:

--- a/ramanujantools/limit.py
+++ b/ramanujantools/limit.py
@@ -29,14 +29,20 @@ def most_round_in_range(num: mp.mpf, err: mp.mpf) -> str:
     return min(round_attempt(num, num + err), round_attempt(num, num - err), key=len)
 
 
-class Limit(Matrix):
+class Limit:
     r"""
     Represents a mathematical limit of a `walk` operation.
+
+    Contains two matrices for the two last steps of calculation.
+    Uses the last step to extract constants, and the previous one to determine precision.
     """
 
+    def __init__(self, current: Matrix, previous: Matrix = None):
+        self.current = current
+        self.previous = previous
+
     def __repr__(self) -> str:
-        matrix_string = repr(Matrix(self)).replace("Matrix(", "")[:-1]
-        return f"Limit({matrix_string})"
+        return f"Limit({self.current}, {self.previous})"
 
     def __str__(self) -> str:
         return repr(self)
@@ -64,8 +70,8 @@ class Limit(Matrix):
         Returns:
             A list of the form [p, q], representing the rational number.
         """
-        p = sp.Rational(self[p_index, column_index])
-        q = sp.Rational(self[q_index, column_index])
+        p = sp.Rational(self.current[p_index, column_index])
+        q = sp.Rational(self.current[q_index, column_index])
         return [
             sp.Integer(p.numerator * q.denominator),
             sp.Integer(p.denominator * q.numerator),

--- a/ramanujantools/limit_test.py
+++ b/ramanujantools/limit_test.py
@@ -6,13 +6,6 @@ from ramanujantools import Matrix, Limit
 from .limit import most_round_in_range
 
 
-def test_equality():
-    matrix = Matrix([[1, 2], [3, 4]])
-    limit1 = Limit(matrix * 17)
-    limit2 = Limit(matrix * 31)
-    assert limit1 == limit2
-
-
 def test_as_rational():
     p = 2
     q = 3

--- a/ramanujantools/limit_test.py
+++ b/ramanujantools/limit_test.py
@@ -2,35 +2,35 @@ from pytest import approx
 
 from mpmath import mp
 
-from ramanujantools import Limit
+from ramanujantools import Matrix, Limit
 from .limit import most_round_in_range
 
 
 def test_equality():
-    base_limit = Limit([[1, 2], [3, 4]])
-    limit1 = base_limit * 17
-    limit2 = base_limit * 31
+    matrix = Matrix([[1, 2], [3, 4]])
+    limit1 = Limit(matrix * 17)
+    limit2 = Limit(matrix * 31)
     assert limit1 == limit2
 
 
 def test_as_rational():
     p = 2
     q = 3
-    limit = Limit([[0, p], [1, q]])
+    limit = Limit(Matrix([[0, p], [1, q]]))
     assert [p, q] == limit.as_rational()
 
 
 def test_as_rational_higher_order():
     p = 2
     q = 3
-    limit = Limit([[1, 2, p], [3, 4, q], [5, 6, 7]])
+    limit = Limit(Matrix([[1, 2, p], [3, 4, q], [5, 6, 7]]))
     assert [p, q] == limit.as_rational()
 
 
 def test_as_float():
     p = 2
     q = 3
-    limit = Limit([[0, p], [1, q]])
+    limit = Limit(Matrix([[0, p], [1, q]]))
     assert p / q == approx(limit.as_float(), 1e-7)
 
 
@@ -39,7 +39,7 @@ def test_precision_exact():
     b = a - 1
     desired_error = 5
     denominator = 10**desired_error
-    limit = Limit([[a, b], [denominator, denominator]])
+    limit = Limit(Matrix([[a, b], [denominator, denominator]]))
     assert desired_error == limit.precision()
 
 
@@ -48,7 +48,7 @@ def test_precision_floor():
     b = a - 2
     desired_error = 5
     denominator = 10**desired_error
-    limit = Limit([[a, b], [denominator, denominator]])
+    limit = Limit(Matrix([[a, b], [denominator, denominator]]))
     assert desired_error - 1 == limit.precision()
 
 
@@ -62,3 +62,8 @@ def test_rounding_small_change():
     num = mp.mpf(0.9999999)
     err = mp.mpf(5 * 1e-15)
     assert "0.9999998" == most_round_in_range(num, err)
+
+
+def test_repr():
+    limit = Limit(Matrix([[1, 2], [3, 4]]))
+    assert limit == eval(repr(limit))

--- a/ramanujantools/limit_test.py
+++ b/ramanujantools/limit_test.py
@@ -6,24 +6,28 @@ from ramanujantools import Matrix, Limit
 from .limit import most_round_in_range
 
 
+def limit_for_tests(matrix: Matrix) -> Limit:
+    return Limit(matrix, Matrix([0]))
+
+
 def test_as_rational():
     p = 2
     q = 3
-    limit = Limit(Matrix([[0, p], [1, q]]))
+    limit = limit_for_tests(Matrix([[0, p], [1, q]]))
     assert [p, q] == limit.as_rational()
 
 
 def test_as_rational_higher_order():
     p = 2
     q = 3
-    limit = Limit(Matrix([[1, 2, p], [3, 4, q], [5, 6, 7]]))
+    limit = limit_for_tests(Matrix([[1, 2, p], [3, 4, q], [5, 6, 7]]))
     assert [p, q] == limit.as_rational()
 
 
 def test_as_float():
     p = 2
     q = 3
-    limit = Limit(Matrix([[0, p], [1, q]]))
+    limit = limit_for_tests(Matrix([[0, p], [1, q]]))
     assert p / q == approx(limit.as_float(), 1e-7)
 
 
@@ -32,7 +36,7 @@ def test_precision_exact():
     b = a - 1
     desired_error = 5
     denominator = 10**desired_error
-    limit = Limit(Matrix([[a, b], [denominator, denominator]]))
+    limit = limit_for_tests(Matrix([[a, b], [denominator, denominator]]))
     assert desired_error == limit.precision()
 
 
@@ -41,7 +45,7 @@ def test_precision_floor():
     b = a - 2
     desired_error = 5
     denominator = 10**desired_error
-    limit = Limit(Matrix([[a, b], [denominator, denominator]]))
+    limit = limit_for_tests(Matrix([[a, b], [denominator, denominator]]))
     assert desired_error - 1 == limit.precision()
 
 
@@ -58,5 +62,5 @@ def test_rounding_small_change():
 
 
 def test_repr():
-    limit = Limit(Matrix([[1, 2], [3, 4]]))
+    limit = limit_for_tests(Matrix([[1, 2], [3, 4]]))
     assert limit == eval(repr(limit))

--- a/ramanujantools/limit_test.py
+++ b/ramanujantools/limit_test.py
@@ -36,7 +36,9 @@ def test_precision_exact():
     b = a - 1
     desired_error = 5
     denominator = 10**desired_error
-    limit = limit_for_tests(Matrix([[a, b], [denominator, denominator]]))
+    limit = Limit(
+        Matrix([[a, b], [denominator, denominator]]), Matrix([[0, a], [1, denominator]])
+    )
     assert desired_error == limit.precision()
 
 
@@ -45,7 +47,9 @@ def test_precision_floor():
     b = a - 2
     desired_error = 5
     denominator = 10**desired_error
-    limit = limit_for_tests(Matrix([[a, b], [denominator, denominator]]))
+    limit = Limit(
+        Matrix([[a, b], [denominator, denominator]]), Matrix([[0, a], [1, denominator]])
+    )
     assert desired_error - 1 == limit.precision()
 
 

--- a/ramanujantools/matrix.py
+++ b/ramanujantools/matrix.py
@@ -261,6 +261,7 @@ class Matrix(sp.Matrix):
         """
         if not self.is_square():
             raise ValueError("Can only inflate square matrices")
+        c = sp.simplify(c)
         m = c * self.coboundary(
             Matrix.inflation_coboundary_matrix(N=self.rows, c=c, symbol=symbol)
         )
@@ -395,6 +396,18 @@ class Matrix(sp.Matrix):
                         if `start` and `trajectory` have different keys,
                         if `iterations` contains duplicate values
         """
+
+        if not self.is_square():
+            raise ValueError(
+                f"Matrix.walk is only supported for square matrices, got a {self.rows}x{self.cols} matrix"
+            )
+
+        if start.keys() != trajectory.keys():
+            raise ValueError(
+                f"`start` and `trajectory` must contain same keys, got "
+                f"start={set(start.keys())}, trajectory={set(trajectory.keys())}"
+            )
+
         iterations_set = set(iterations)
         if len(iterations_set) != len(iterations):
             raise ValueError(f"`iterations` values must be unique, got {iterations}")
@@ -413,7 +426,7 @@ class Matrix(sp.Matrix):
         previous_depth = 0
         for depth in iterations:
             effective_depth = depth - previous_depth
-            matrix *= self.walk(trajectory, effective_depth, position)
+            matrix *= self.walk(trajectory, effective_depth, position, validate=False)
             position = {
                 key: position[key] + value * effective_depth
                 for key, value in trajectory.items()
@@ -424,21 +437,22 @@ class Matrix(sp.Matrix):
 
     @multimethod
     def walk(  # noqa: F811
-        self, trajectory: Dict, iterations: int, start: Dict
+        self, trajectory: Dict, iterations: int, start: Dict, validate=True
     ) -> Matrix:
-        if not self.is_square():
-            raise ValueError(
-                f"Matrix.walk is only supported for square matrices, got a {self.rows}x{self.cols} matrix"
-            )
+        if validate:
+            if not self.is_square():
+                raise ValueError(
+                    f"Matrix.walk is only supported for square matrices, got a {self.rows}x{self.cols} matrix"
+                )
 
-        if start.keys() != trajectory.keys():
-            raise ValueError(
-                f"`start` and `trajectory` must contain same keys, got "
-                f"start={set(start.keys())}, trajectory={set(trajectory.keys())}"
-            )
+            if start.keys() != trajectory.keys():
+                raise ValueError(
+                    f"`start` and `trajectory` must contain same keys, got "
+                    f"start={set(start.keys())}, trajectory={set(trajectory.keys())}"
+                )
 
-        if iterations < 0:
-            raise ValueError(f"iterations must be non-negative, got {iterations}")
+            if iterations < 0:
+                raise ValueError(f"iterations must be non-negative, got {iterations}")
 
         position = start
         matrix = Matrix.eye(self.rows)

--- a/ramanujantools/matrix.py
+++ b/ramanujantools/matrix.py
@@ -462,6 +462,16 @@ class Matrix(sp.Matrix):
             position = {key: trajectory[key] + value for key, value in position.items()}
         return matrix
 
+    @multimethod
+    def limit(self, trajectory: Dict, iterations: List[int], start: Dict):  # noqa: F811
+        from ramanujantools import Limit
+
+        return [Limit(matrix) for matrix in self.walk(trajectory, iterations, start)]
+
+    @multimethod
+    def limit(self, trajectory: Dict, iterations: int, start: Dict):  # noqa: F811
+        return self.limit(trajectory, [iterations], start)[0]
+
     def as_pcf(self, deflate_all=True):
         """
         Converts a `Matrix` to an equivalent `PCF`

--- a/ramanujantools/matrix.py
+++ b/ramanujantools/matrix.py
@@ -16,6 +16,26 @@ class Matrix(sp.Matrix):
     https://docs.sympy.org/latest/modules/matrices/matrices.html
     """
 
+    @staticmethod
+    def e(N: int, index: int, column=True) -> Matrix:
+        r"""
+        Returns a coordinate vector of size N for a given index, i.e,
+        a vector of size N of zeroes with 1 in the corresponding index
+
+        Args:
+            N: The vector size
+            index: The index of the given axis
+            column: will return the vector in column form if true, in row form otherwise.
+        Returns:
+            The desired coordinate vector described above
+        """
+        if index >= N:
+            raise ValueError(f"Cannot create {index}th axis vector of size {N}")
+        if column:
+            return Matrix.eye(N).col(index)
+        else:
+            return Matrix.eye(N).row(index)
+
     def __str__(self) -> str:
         return repr(self)
 

--- a/ramanujantools/matrix.py
+++ b/ramanujantools/matrix.py
@@ -466,7 +466,22 @@ class Matrix(sp.Matrix):
     def limit(self, trajectory: Dict, iterations: List[int], start: Dict):  # noqa: F811
         from ramanujantools import Limit
 
-        return [Limit(matrix) for matrix in self.walk(trajectory, iterations, start)]
+        previous_values = [depth - 1 for depth in iterations]
+        walk_iterations = sorted(list(set(iterations + previous_values)))
+        walk_matrices = self.walk(trajectory, walk_iterations, start)
+
+        current_index = 0
+        limits = []
+        for depth in iterations:
+            while depth != walk_iterations[current_index]:
+                current_index += 1
+            limits.append(
+                Limit(
+                    walk_matrices[current_index],
+                    walk_matrices[current_index - 1],
+                )
+            )
+        return limits
 
     @multimethod
     def limit(self, trajectory: Dict, iterations: int, start: Dict):  # noqa: F811

--- a/ramanujantools/matrix.py
+++ b/ramanujantools/matrix.py
@@ -466,22 +466,10 @@ class Matrix(sp.Matrix):
     def limit(self, trajectory: Dict, iterations: List[int], start: Dict):  # noqa: F811
         from ramanujantools import Limit
 
-        previous_values = [depth - 1 for depth in iterations]
-        walk_iterations = sorted(list(set(iterations + previous_values)))
-        walk_matrices = self.walk(trajectory, walk_iterations, start)
+        def walk_function(iterations):
+            return self.walk(trajectory, iterations, start)
 
-        current_index = 0
-        limits = []
-        for depth in iterations:
-            while depth != walk_iterations[current_index]:
-                current_index += 1
-            limits.append(
-                Limit(
-                    walk_matrices[current_index],
-                    walk_matrices[current_index - 1],
-                )
-            )
-        return limits
+        return Limit.walk_to_limit(iterations, walk_function)
 
     @multimethod
     def limit(self, trajectory: Dict, iterations: int, start: Dict):  # noqa: F811

--- a/ramanujantools/matrix_test.py
+++ b/ramanujantools/matrix_test.py
@@ -1,7 +1,7 @@
 import sympy as sp
 from sympy.abc import x, y, n
 
-from ramanujantools import Matrix, simplify
+from ramanujantools import Matrix, Limit, simplify
 
 
 def test_is_square():
@@ -278,3 +278,23 @@ def test_walk_different_start():
     assert simplify(m.walk({x: 3, y: 2}, 3, {x: 5, y: 7})) == simplify(
         m({x: 5, y: 7}) * m({x: 8, y: 9}) * m({x: 11, y: 11})
     )
+
+
+def test_walk_equivalent_to_limit_single():
+    trajectory = {x: 2, y: 3}
+    start = {x: 5, y: 7}
+    iterations = 17
+    m = Matrix([[x, 3 * x + 5 * y], [y**7 + x - 3, x**5]])
+    assert m.limit(trajectory, iterations, start) == Limit(
+        m.walk(trajectory, iterations, start)
+    )
+
+
+def test_walk_equivalent_to_limit_list():
+    trajectory = {x: 2, y: 3}
+    start = {x: 5, y: 7}
+    iterations = [1, 2, 3, 17, 29, 53, 99]
+    m = Matrix([[x, 3 * x + 5 * y], [y**7 + x - 3, x**5]])
+    assert m.limit(trajectory, iterations, start) == [
+        Limit(matrix) for matrix in m.walk(trajectory, iterations, start)
+    ]

--- a/ramanujantools/matrix_test.py
+++ b/ramanujantools/matrix_test.py
@@ -280,21 +280,22 @@ def test_walk_different_start():
     )
 
 
-def test_walk_equivalent_to_limit_single():
+def test_walk_equivalent_to_limit():
     trajectory = {x: 2, y: 3}
     start = {x: 5, y: 7}
     iterations = 17
     m = Matrix([[x, 3 * x + 5 * y], [y**7 + x - 3, x**5]])
-    assert m.limit(trajectory, iterations, start) == Limit(
-        m.walk(trajectory, iterations, start)
-    )
+    m_previous, m_last = m.walk(trajectory, [iterations - 1, iterations], start)
+    assert m.limit(trajectory, iterations, start) == Limit(m_last, m_previous)
 
 
-def test_walk_equivalent_to_limit_list():
+def test_limit_list():
     trajectory = {x: 2, y: 3}
     start = {x: 5, y: 7}
     iterations = [1, 2, 3, 17, 29, 53, 99]
     m = Matrix([[x, 3 * x + 5 * y], [y**7 + x - 3, x**5]])
-    assert m.limit(trajectory, iterations, start) == [
-        Limit(matrix) for matrix in m.walk(trajectory, iterations, start)
-    ]
+    limits = m.limit(trajectory, iterations, start)
+    for depth_index in range(len(iterations)):
+        assert limits[depth_index] == m.limit(
+            trajectory, iterations[depth_index], start
+        )

--- a/ramanujantools/pcf/pcf.py
+++ b/ramanujantools/pcf/pcf.py
@@ -1,7 +1,7 @@
 import sympy as sp
 from sympy.abc import n
 
-from typing import Dict, List, Collection
+from typing import Dict, List, Collection, Union
 from multimethod import multimethod
 
 from ramanujantools import Matrix, Limit
@@ -202,7 +202,13 @@ class PCF:
     def limit(self, iterations: int, start: int = 0) -> Limit:  # noqa: F811
         return self.limit([iterations], start)[0]
 
-    def delta(self, depth, limit=None):
+    def delta(
+        self,
+        depth,
+        limit=None,
+        p_vectors: Union[List[Matrix], type(None)] = None,
+        q_vectors: Union[List[Matrix], type(None)] = None,
+    ):
         r"""
         Calculates the irrationality measure $\delta$ defined, as:
         $|\frac{p_n}{q_n} - L| = \frac{1}{q_n}^{1+\delta}$
@@ -213,6 +219,8 @@ class PCF:
         Args:
             depth: $n$
             limit: $L$
+            p_vectors: numerator extraction vectors for delta
+            q_vectors: denominator extraction vectors for delta
         Returns:
             the delta value as defined above.
         Raises:
@@ -227,9 +235,15 @@ class PCF:
             limit = mlim.as_float()
         else:
             m = self.limit(depth)
-        return m.delta(limit)
+        return m.delta(limit, p_vectors, q_vectors)
 
-    def delta_sequence(self, depth: int, limit: float = None):
+    def delta_sequence(
+        self,
+        depth: int,
+        limit: float = None,
+        p_vectors: Union[List[Matrix], type(None)] = None,
+        q_vectors: Union[List[Matrix], type(None)] = None,
+    ):
         r"""
         Calculates the irrationality measure $\delta$ defined, as:
         $|\frac{p_n}{q_n} - L| = \frac{1}{q_n}^{1+\delta}$
@@ -240,6 +254,8 @@ class PCF:
         Args:
             depth: $n$
             limit: $L$
+            p_vectors: numerator extraction vectors for delta
+            q_vectors: denominator extraction vectors for delta
         Returns:
             the delta values for all depths up to `depth` as defined above.
         Raises:
@@ -255,11 +271,11 @@ class PCF:
         deltas = []
         prev = Matrix.eye(2)
         m = self.A()
-        deltas.append(Limit(m, prev).delta(limit))
+        deltas.append(Limit(m, prev).delta(limit, p_vectors, q_vectors))
 
         for i in range(1, depth):
             prev = m
             m *= self.M()({n: i})
-            deltas.append(Limit(m, prev).delta(limit))
+            deltas.append(Limit(m, prev).delta(limit, p_vectors, q_vectors))
 
         return deltas

--- a/ramanujantools/pcf/pcf.py
+++ b/ramanujantools/pcf/pcf.py
@@ -158,12 +158,11 @@ class PCF:
             raise ValueError(
                 f"iterations must contain only positive values, got {iterations}"
             )
+        actual_iterations = [depth - 1 for depth in iterations]
         if start == 0:
             return [
                 self.A() * matrix
-                for matrix in self.M().walk(
-                    {n: 1}, [iteration - 1 for iteration in iterations], {n: 1}
-                )
+                for matrix in self.M().walk({n: 1}, actual_iterations, {n: 1})
             ]
         return self.M().walk({n: 1}, iterations, {n: start})
 

--- a/ramanujantools/pcf/pcf.py
+++ b/ramanujantools/pcf/pcf.py
@@ -253,11 +253,13 @@ class PCF:
             limit = self.limit(2 * depth).as_float()
 
         deltas = []
+        prev = Matrix.eye(2)
         m = self.A()
-        deltas.append(Limit(m).delta(limit))
+        deltas.append(Limit(m, prev).delta(limit))
 
         for i in range(1, depth):
+            prev = m
             m *= self.M()({n: i})
-            deltas.append(Limit(m).delta(limit))
+            deltas.append(Limit(m, prev).delta(limit))
 
         return deltas

--- a/ramanujantools/pcf/pcf_test.py
+++ b/ramanujantools/pcf/pcf_test.py
@@ -2,7 +2,7 @@ from pytest import approx
 from sympy.abc import c, n
 import mpmath as mp
 
-import ramanujantools as rt
+from ramanujantools import Matrix
 from ramanujantools.pcf import PCF
 
 
@@ -39,7 +39,7 @@ def test_walk_start():
     iterations = [1, 2, 3, 17, 29, 53, 99]
     p = PCF(n + 7, 3 * n**2 - 1)
     expected = p.walk(sum(iterations))
-    actual = rt.Matrix.eye(2)
+    actual = Matrix.eye(2)
     for i in range(len(iterations)):
         actual *= p.walk(iterations[i], start=sum(iterations[0:i]))
     assert expected == actual
@@ -126,15 +126,17 @@ def test_precision_phi():
 
 def test_delta_sequence_agrees_with_delta():
     # To prevent dynamic precision errors, setting it high enough
+    p_vectors = [Matrix([[1, 1]]), Matrix([[0], [1]])]
+    q_vectors = [Matrix([[1, 0]]), Matrix([[1], [1]])]
     mp.mp.dps = 50
     pcf = PCF(2 * n + 1, n**2)
     depth = 50
     limit = 4 / mp.pi
 
-    actual_deltas = pcf.delta_sequence(depth, limit)
+    actual_deltas = pcf.delta_sequence(depth, limit, p_vectors, q_vectors)
     expected_deltas = []
     for dep in range(1, depth + 1):
-        expected_deltas.append(pcf.delta(dep, limit))
+        expected_deltas.append(pcf.delta(dep, limit, p_vectors, q_vectors))
 
     assert expected_deltas == actual_deltas
 

--- a/ramanujantools/pcf/pcf_test.py
+++ b/ramanujantools/pcf/pcf_test.py
@@ -36,7 +36,7 @@ def test_walk_list():
 
 
 def test_walk_start():
-    iterations = [1]
+    iterations = [1, 2, 3, 17, 29, 53, 99]
     p = PCF(n + 7, 3 * n**2 - 1)
     expected = p.walk(sum(iterations))
     actual = rt.Matrix.eye(2)


### PR DESCRIPTION
Implement advanced limit.
The rational number (p and q) is now extracted using extraction vectors: we receive two extraction vectors v1 (row) and v2 (column), such that the extracted number is `v1 * M * v2`.

This is expected to be a temporal interface until our research suggests a better option. Until then, we keep this interface as it's very expressive and generic.

The old interface was `limit.as_rational(p_index=0, q_index=1)`.
The new interface is `limit.as_rational(p_vectors=[vp1, vp2], q_vectors=[vq1, vq2])`.
The default value for `p_vectors` and `q_vectors` is None, in which case the extracted values are same as before (top-right for p, and one below for q).