### PR TITLE
Update to python3.12

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.8", "3.12"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Make CI run the pipeline with python3.12 instead of python3.11