### PR TITLE
Hotfix/walk-rational-position

### DIFF
--- a/ramanujantools/cmf/cmf.py
+++ b/ramanujantools/cmf/cmf.py
@@ -190,14 +190,21 @@ class CMF:
         for value in start.values():
             free_symbols = free_symbols.union(set(sp.simplify(value).free_symbols))
 
-        result = FlintMatrix.eye(self.N(), free_symbols)
+        flint = start.is_polynomial() and trajectory.is_polynomial()
+        result = (
+            FlintMatrix.eye(self.N(), free_symbols) if flint else Matrix.eye(self.N())
+        )
         position = start.copy()
         for axis in self.axes_sorter(self.axes(), trajectory, start):
             if trajectory[axis] == 0:
                 continue
             sign = trajectory[axis] >= 0
             current = self.M(axis, sign)
-            result *= FlintMatrix.from_sympy(current, free_symbols).subs(position)
+            result *= (
+                FlintMatrix.from_sympy(current, free_symbols).subs(position)
+                if flint
+                else current.subs(position)
+            )
             position[axis] += trajectory[axis]
         return result.factor()
 

--- a/ramanujantools/cmf/cmf.py
+++ b/ramanujantools/cmf/cmf.py
@@ -234,10 +234,10 @@ class CMF:
             )
 
         trajectory = Position(trajectory)
-        position = Position(
+        position = (
             CMF.variable_reduction_substitution(trajectory, start, symbol)
             if start is not None
-            else {axis: axis for axis in self.axes()}
+            else Position({axis: axis for axis in self.axes()})
         )
 
         # Stopping condition: l-infinity norm of trajectory is less than 1
@@ -256,8 +256,8 @@ class CMF:
 
     @staticmethod
     def variable_reduction_substitution(
-        trajectory: Dict, start: Dict, symbol: sp.Symbol
-    ) -> Matrix:
+        trajectory: Position, start: Position, symbol: sp.Symbol
+    ) -> Position:
         """
         Returns the substitution that reduces all CMF variables into one variable.
 
@@ -278,10 +278,7 @@ class CMF:
                 f"Trajectory axes {trajectory.keys()} do not match start axes {start.keys()}"
             )
 
-        return {
-            axis: start[axis] + (symbol - 1) * trajectory[axis]
-            for axis in trajectory.keys()
-        }
+        return Position(start) + (symbol - 1) * Position(trajectory)
 
     @multimethod
     def walk(  # noqa: F811

--- a/ramanujantools/cmf/cmf_benchmark.py
+++ b/ramanujantools/cmf/cmf_benchmark.py
@@ -22,6 +22,15 @@ def test_trajectory_matrix_2f2_euler(benchmark):
     benchmark(CMF.trajectory_matrix, cmf, trajectory, start)
 
 
+def test_trajectory_matrix_2f2_deep(benchmark):
+    x0, x1 = sp.symbols("x:2")
+    y0, y1 = sp.symbols("y:2")
+    cmf = pFq(2, 2, -1)
+    start = {x0: 1, x1: 1, y0: -1, y1: 1}
+    trajectory = {x0: 12, x1: 13, y0: -14, y1: 20}
+    benchmark(CMF.trajectory_matrix, cmf, trajectory, start)
+
+
 def test_trajectory_matrix_3f2(benchmark):
     x0, x1, x2 = sp.symbols("x:3")
     y0, y1 = sp.symbols("y:2")
@@ -49,10 +58,10 @@ def test_trajectory_matrix_4f3(benchmark):
     benchmark(CMF.trajectory_matrix, cmf, trajectory, start)
 
 
-def test_trajectory_matrix_2f2_deep(benchmark):
-    x0, x1 = sp.symbols("x:2")
-    y0, y1 = sp.symbols("y:2")
-    cmf = pFq(2, 2, -1)
-    start = {x0: 1, x1: 1, y0: -1, y1: 1}
-    trajectory = {x0: 12, x1: 13, y0: -14, y1: 20}
+def test_trajectory_matrix_4f3_huge(benchmark):
+    x0, x1, x2, x3 = sp.symbols("x:4")
+    y0, y1, y2 = sp.symbols("y:3")
+    cmf = pFq(4, 3, 1)
+    trajectory = {x0: -1, x1: 1, x2: 2, x3: -2, y0: 3, y1: 7, y2: 4}
+    start = trajectory
     benchmark(CMF.trajectory_matrix, cmf, trajectory, start)

--- a/ramanujantools/cmf/cmf_benchmark.py
+++ b/ramanujantools/cmf/cmf_benchmark.py
@@ -22,15 +22,6 @@ def test_trajectory_matrix_2f2_euler(benchmark):
     benchmark(CMF.trajectory_matrix, cmf, trajectory, start)
 
 
-def test_trajectory_matrix_2f2_deep(benchmark):
-    x0, x1 = sp.symbols("x:2")
-    y0, y1 = sp.symbols("y:2")
-    cmf = pFq(2, 2, -1)
-    start = {x0: 1, x1: 1, y0: -1, y1: 1}
-    trajectory = {x0: 12, x1: 13, y0: -14, y1: 20}
-    benchmark(CMF.trajectory_matrix, cmf, trajectory, start)
-
-
 def test_trajectory_matrix_3f2(benchmark):
     x0, x1, x2 = sp.symbols("x:3")
     y0, y1 = sp.symbols("y:2")
@@ -55,4 +46,13 @@ def test_trajectory_matrix_4f3(benchmark):
     cmf = pFq(4, 3, 1)
     start = {x0: 1, x1: 1, x2: 2, x3: 2, y0: 3, y1: 3, y2: 4}
     trajectory = {x0: 1, x1: 1, x2: 2, x3: 2, y0: 3, y1: 3, y2: 4}
+    benchmark(CMF.trajectory_matrix, cmf, trajectory, start)
+
+
+def test_trajectory_matrix_2f2_deep(benchmark):
+    x0, x1 = sp.symbols("x:2")
+    y0, y1 = sp.symbols("y:2")
+    cmf = pFq(2, 2, -1)
+    start = {x0: 1, x1: 1, y0: -1, y1: 1}
+    trajectory = {x0: 12, x1: 13, y0: -14, y1: 20}
     benchmark(CMF.trajectory_matrix, cmf, trajectory, start)

--- a/ramanujantools/cmf/cmf_test.py
+++ b/ramanujantools/cmf/cmf_test.py
@@ -1,7 +1,9 @@
 from pytest import raises
+
+import sympy as sp
 from sympy.abc import a, b, c, x, y, n
 
-from ramanujantools import Matrix, simplify
+from ramanujantools import Position, Matrix, simplify
 from ramanujantools.cmf import CMF, known_cmfs
 
 
@@ -77,6 +79,19 @@ def test_trajectory_matrix_variable_reduction():
     assert cmf.trajectory_matrix(trajectory).subs(
         CMF.variable_reduction_substitution(trajectory, start, n)
     ) == cmf.trajectory_matrix(trajectory, start)
+
+
+def test_trajectory_matrix_rational():
+    cmf = known_cmfs.e()
+    start = Position({x: sp.Rational(2, 3), y: sp.Rational(1, 4)})
+    trajectory = {x: 1, y: 1}
+    symbolic_start = CMF.variable_reduction_substitution(trajectory, start, n)
+    expected = (
+        cmf.M(x).subs(symbolic_start) * cmf.M(y).subs(symbolic_start + Position({x: 1}))
+    ).factor()
+    actual = cmf.trajectory_matrix({x: 1, y: 1}, start)
+    print(expected, actual)
+    assert expected == actual
 
 
 def test_walk_axis():

--- a/ramanujantools/cmf/cmf_test.py
+++ b/ramanujantools/cmf/cmf_test.py
@@ -90,7 +90,6 @@ def test_trajectory_matrix_rational():
         cmf.M(x).subs(symbolic_start) * cmf.M(y).subs(symbolic_start + Position({x: 1}))
     ).factor()
     actual = cmf.trajectory_matrix({x: 1, y: 1}, start)
-    print(expected, actual)
     assert expected == actual
 
 

--- a/ramanujantools/cmf/known_cmfs/known_cmfs.py
+++ b/ramanujantools/cmf/known_cmfs/known_cmfs.py
@@ -144,7 +144,7 @@ def hypergeometric_derived_3F2() -> CMF:
         [
             [0, 0, Px / ((1 - z) * z)],
             [z, 1, ((Tx + Sx + 1) * z - Ty) / ((1 - z) * z)],
-            [0, z, ((Sx + 1) * z + Sy + 1) / ((1 - z))],
+            [0, z, ((Sx + 1) * z + Sy + 1) / (1 - z)],
         ],
     )
     I3 = sp.eye(3)

--- a/ramanujantools/matrix.py
+++ b/ramanujantools/matrix.py
@@ -87,13 +87,6 @@ class Matrix(sp.Matrix):
             and start.is_polynomial()
         )
 
-    def _can_call_numerical_walk(self, substitutions: Dict) -> bool:
-        """
-        Returns true iff all substitutions are numerical
-        """
-        substitutions = Position(substitutions)
-        return substitutions.keys() == self.free_symbols and substitutions.is_numeric()
-
     def _can_call_numerical_subs(self, substitutions: Dict) -> bool:
         """
         Returns true iff the all substitutions are numerical and we can can call `numerical_subs` instead of `xreplace`.

--- a/ramanujantools/matrix.py
+++ b/ramanujantools/matrix.py
@@ -75,8 +75,14 @@ class Matrix(sp.Matrix):
         return self.xreplace(substitutions)
 
     def _can_call_flint_walk(self, trajectory: Dict, start: Dict) -> bool:
+        trajectory = Position(trajectory)
+        start = Position(start)
+
+        subbed_in = trajectory.free_symbols().union(start.free_symbols())
+        subbed_out = set(trajectory.keys()).union(set(start.keys()))
+
         return (
-            self.free_symbols - set(start.keys()).union(trajectory.keys()) != set()
+            (self.free_symbols - subbed_out).union(subbed_in) != set()
             and trajectory.is_polynomial()
             and start.is_polynomial()
         )

--- a/ramanujantools/matrix_test.py
+++ b/ramanujantools/matrix_test.py
@@ -43,6 +43,25 @@ def test_can_call_numerical_subs():
     assert m._can_call_numerical_subs({x: 17, y: 31})
 
 
+def test_can_call_flint_walk():
+    m = Matrix([[x, 1], [y, 2]])
+
+    # flint is slow for numerical walk (both integer and rational)
+    assert not m._can_call_flint_walk({x: 1, y: 1}, {x: 1, y: 1})
+    assert not m._can_call_flint_walk(
+        {x: 1, y: 1}, {x: sp.Rational(1, 2), y: sp.Rational(1, 2)}
+    )
+
+    # x remains a symbol
+    assert m._can_call_flint_walk({x: 1, y: 1}, {x: x, y: 1})
+
+    # currently not supporting rational coefficients of symbolic polynomials
+    assert not m._can_call_flint_walk({x: 1, y: 1}, {x: x / 2, y: 1})
+
+    # substituting a different symbol causes symbolic flint calculation
+    assert m._can_call_flint_walk({x: 1, y: 1}, {x: n - 1, y: n**2})
+
+
 def test_subs_degenerated():
     m = Matrix([[x, 1], [y, 2]])
     assert m == m.subs({x: x})

--- a/ramanujantools/position.py
+++ b/ramanujantools/position.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Dict
+from typing import Dict, Set
 
 import sympy as sp
 
@@ -93,3 +93,9 @@ class Position(dict):
         Returns true iff all position elements are numerical
         """
         return all(sp.simplify(element).is_Integer for element in self.values())
+
+    def free_symbols(self) -> Set:
+        symbols = set()
+        for value in self.values():
+            symbols = symbols.union((sp.simplify(0) + value).free_symbols)
+        return symbols

--- a/ramanujantools/position.py
+++ b/ramanujantools/position.py
@@ -73,3 +73,23 @@ class Position(dict):
         Returns the sign in each direction of this
         """
         return Position({key: int(sp.sign(value)) for key, value in self.items()})
+
+    def is_polynomial(self) -> bool:
+        """
+        Returns true iff all position elements are numerical
+        """
+        for element in self.values():
+            if not all(
+                [
+                    c.is_Integer
+                    for c in sp.simplify(element).as_coefficients_dict().values()
+                ]
+            ):
+                return False
+        return True
+
+    def is_integer(self) -> bool:
+        """
+        Returns true iff all position elements are numerical
+        """
+        return all(sp.simplify(element).is_Integer for element in self.values())

--- a/ramanujantools/position_test.py
+++ b/ramanujantools/position_test.py
@@ -1,3 +1,4 @@
+import sympy as sp
 from sympy.abc import x, y, z
 
 from ramanujantools import Position
@@ -66,3 +67,21 @@ def test_signs():
 
 def test_signs_empty():
     assert Position() == Position().signs()
+
+
+def test_is_integer():
+    assert Position({x: 1, y: 7}).is_integer()
+    assert not Position({x: 1, y: x**2 + 3 * x + 1}).is_integer()
+    assert not Position({x: x / 2, y: x**2 + 3 * x + 1}).is_integer()
+    assert not Position({x: sp.Rational(1, 2), y: 1}).is_integer()
+
+
+def test_is_polynomial():
+    assert Position({x: 1, y: 7}).is_polynomial()
+    assert Position({x: 1, y: x**2 + 3 * x + 1}).is_polynomial()
+    assert not Position({x: x / 2, y: x**2 + 3 * x + 1}).is_polynomial()
+    assert not Position({x: sp.Rational(1, 2), y: 1}).is_polynomial()
+
+
+def test_free_symbols():
+    assert {x, z} == Position({x: 1, y: z, z: x}).free_symbols()


### PR DESCRIPTION
Fix the use-case of rational coordinates in the starting position of `Matrix.walk`, `CMF.walk` and `CMF.trajectory_matrix`.
For now - we simply do not use the Flint optimization for this use-case.

In Flint (C++) there's a class called `fmpq_mpoly` which supports multivariate polynomials with rational coefficients (which exists in `python-flint`), and another class called `fmpz_mpoly_q` which support multivariate rational functions with integer coefficients (and does not exist in `python-flint`). Unfortunately there is no such `fmpq_mpoly_q` class for rational functions with rational coefficients even in the C++ library.

It is possible to extend our FlintRational wrapper to use `fmpq_mpoly`. Both the numerator and denominator polynomials should be able to extract the lcm of all denominators of all coefficients, and then we can normalize them using the other polynomial.