### PR TITLE
bugfix/walk-symbol-collision

### DIFF
--- a/ramanujantools/cmf/cmf.py
+++ b/ramanujantools/cmf/cmf.py
@@ -247,8 +247,9 @@ class CMF:
         result = Matrix.eye(self.N())
         depth = trajectory.shortest()
         while depth > 0:
+            inner_symbol = sp.Symbol(f"{symbol}{depth}")
             diagonal = trajectory.signs()
-            result *= self.walk(diagonal, depth, position)
+            result *= self.walk(diagonal, depth, position, inner_symbol)
             position += depth * diagonal
             trajectory -= depth * diagonal
             depth = trajectory.shortest()
@@ -286,6 +287,7 @@ class CMF:
         trajectory: Dict,
         iterations: List[int],
         start: Dict,
+        symbol=sp.Symbol("walk"),
     ) -> List[Matrix]:
         r"""
         Returns a list of trajectorial walk multiplication matrices in the desired depths.
@@ -313,11 +315,8 @@ class CMF:
                 f"iterations must contain only non-negative values, got {iterations}"
             )
 
-        walk_symbol = sp.Symbol("walk")
-        trajectory_matrix = self.trajectory_matrix(
-            trajectory, start, symbol=walk_symbol
-        )
-        return trajectory_matrix.walk({walk_symbol: 1}, iterations, {walk_symbol: 1})
+        trajectory_matrix = self.trajectory_matrix(trajectory, start, symbol=symbol)
+        return trajectory_matrix.walk({symbol: 1}, iterations, {symbol: 1})
 
     @multimethod
     def walk(  # noqa: F811
@@ -325,8 +324,9 @@ class CMF:
         trajectory: Dict,
         iterations: int,
         start: Dict,
+        symbol=sp.Symbol("walk"),
     ) -> Matrix:
-        return self.walk(trajectory, [iterations], start)[0]
+        return self.walk(trajectory, [iterations], start, symbol)[0]
 
     @multimethod
     def limit(

--- a/ramanujantools/cmf/cmf_test.py
+++ b/ramanujantools/cmf/cmf_test.py
@@ -100,6 +100,16 @@ def test_walk_axis():
     assert cmf.walk({x: 0, y: 1}, 17, start) == cmf.M(y).walk({x: 0, y: 1}, 17, start)
 
 
+def test_walk_axis_multiplicity():
+    cmf = known_cmfs.e()
+    start = {x: 1, y: 1}
+    trajectory = Position({x: 1, y: 0})
+    depth = 4
+    assert cmf.walk(depth * trajectory, 1, start) == cmf.M(x).walk(
+        trajectory, depth, start
+    )
+
+
 def test_walk_diagonal():
     cmf = known_cmfs.e()
     trajectory = {x: 1, y: 1}


### PR DESCRIPTION
Fix a bug where through recursion walk symbol was used twice (CMF.walk -> CMF.trajectory_matrix -> CMF.walk).
Thanks to @ElyasheevLeibtag for spotting this bug.