### PR TITLE
bugfix/as-rounded-number

### DIFF
--- a/ramanujantools/limit.py
+++ b/ramanujantools/limit.py
@@ -18,15 +18,15 @@ def first_unmatch(a: str, b: str) -> int:
     return size
 
 
-def round_attempt(original: mp.mpf, with_error: mp.mpf) -> str:
-    original = str(original)
-    with_error = str(with_error)
-    up_to = first_unmatch(original, with_error) + 1
-    return with_error[0:up_to]
+def round_attempt(lower_bound: mp.mpf, upper_bound: mp.mpf) -> str:
+    lower = str(lower_bound)
+    upper = str(upper_bound)
+    up_to = first_unmatch(lower, upper) + 1
+    return upper[0:up_to]
 
 
 def most_round_in_range(num: mp.mpf, err: mp.mpf) -> str:
-    return min(round_attempt(num, num + err), round_attempt(num, num - err), key=len)
+    return min(round_attempt(num, num + err), round_attempt(num - err, num), key=len)
 
 
 class Limit:
@@ -163,7 +163,7 @@ class Limit:
     def delta(self, L: mp.mpf) -> mp.mpf:
         r"""
         Calculates the irrationality measure $\delta$ defined, as:
-        $|\frac{p_n}{q_n} - L| = \frac{1}{q_n}^{1+\delta}$
+        $|\frac{p_n}{q_n} - L| = \frac{1}{q_n^{1+\delta}}$
         Args:
             L: $L$
         Returns:

--- a/ramanujantools/limit_test.py
+++ b/ramanujantools/limit_test.py
@@ -70,7 +70,7 @@ def test_rounding_whole_number():
 def test_rounding_small_change():
     num = mp.mpf(0.9999999)
     err = mp.mpf(5 * 1e-15)
-    assert "0.9999998" == most_round_in_range(num, err)
+    assert "0.9999999" == most_round_in_range(num, err)
 
 
 def test_repr():

--- a/ramanujantools/limit_test.py
+++ b/ramanujantools/limit_test.py
@@ -53,6 +53,14 @@ def test_precision_floor():
     assert desired_error - 1 == limit.precision()
 
 
+def test_rounding_in_range():
+    for num in [0.49, 0.4999999, 0.5, 0.500001, 0.51]:
+        err = 5 * 1e-2
+        rounded = eval(most_round_in_range(num, err))
+
+        assert abs(num - rounded) < err
+
+
 def test_rounding_whole_number():
     num = 0.9999999
     err = 5 * 1e-5


### PR DESCRIPTION
Fix bug in Limit.as_rounded_number that caused numbers to round down outside of their range (for example, from 0.5 to 0.4)