### PR TITLE
Feature/rational-position-flint

### DIFF
--- a/ramanujantools/cmf/cmf.py
+++ b/ramanujantools/cmf/cmf.py
@@ -191,21 +191,15 @@ class CMF:
         for value in start.values():
             free_symbols = free_symbols.union(set(sp.simplify(value).free_symbols))
 
-        flint = start.is_polynomial() and trajectory.is_polynomial()
-        result = (
-            FlintMatrix.eye(self.N(), free_symbols) if flint else Matrix.eye(self.N())
-        )
         position = start.copy()
+        fmpz = position.is_polynomial()
+        result = FlintMatrix.eye(self.N(), free_symbols, fmpz=fmpz)
         for axis in self.axes_sorter(self.axes(), trajectory, start):
             if trajectory[axis] == 0:
                 continue
             sign = trajectory[axis] >= 0
             current = self.M(axis, sign)
-            result *= (
-                FlintMatrix.from_sympy(current, free_symbols).subs(position)
-                if flint
-                else current.subs(position)
-            )
+            result *= FlintMatrix.from_sympy(current, free_symbols, fmpz).subs(position)
             position[axis] += trajectory[axis]
         return result.factor()
 

--- a/ramanujantools/cmf/cmf.py
+++ b/ramanujantools/cmf/cmf.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
+from typing import Dict, List, Optional, Set
+
 import itertools
 from multimethod import multimethod
-from typing import Dict, List, Optional, Set
 
 import sympy as sp
 from sympy.abc import n
@@ -249,7 +250,7 @@ class CMF:
         while depth > 0:
             inner_symbol = sp.Symbol(f"{symbol}{depth}")
             diagonal = trajectory.signs()
-            result *= self.walk(diagonal, depth, position, inner_symbol)
+            result *= self.walk(diagonal, int(depth), position, inner_symbol)
             position += depth * diagonal
             trajectory -= depth * diagonal
             depth = trajectory.shortest()

--- a/ramanujantools/cmf/cmf_benchmark.py
+++ b/ramanujantools/cmf/cmf_benchmark.py
@@ -40,6 +40,21 @@ def test_trajectory_matrix_3f2(benchmark):
     benchmark(CMF.trajectory_matrix, cmf, trajectory, start)
 
 
+def test_trajectory_matrix_3f2_rational(benchmark):
+    x0, x1, x2 = sp.symbols("x:3")
+    y0, y1 = sp.symbols("y:2")
+    cmf = pFq(3, 2, 1)
+    start = {
+        x0: sp.Rational(1, 2),
+        x1: sp.Rational(1, 2),
+        x2: sp.Rational(1, 2),
+        y0: sp.Rational(3, 2),
+        y1: sp.Rational(3, 2),
+    }
+    trajectory = {x0: 5, x1: 5, x2: 5, y0: 10, y1: 10}
+    benchmark(CMF.trajectory_matrix, cmf, trajectory, start)
+
+
 def test_trajectory_matrix_3f2_pertubated(benchmark):
     x0, x1, x2 = sp.symbols("x:3")
     y0, y1 = sp.symbols("y:2")

--- a/ramanujantools/flint_core/matrix.py
+++ b/ramanujantools/flint_core/matrix.py
@@ -17,11 +17,7 @@ class FlintMatrix:
     """
 
     def __init__(
-        self,
-        rows: int,
-        cols: int,
-        values: List[FlintRational],
-        symbols,
+        self, rows: int, cols: int, values: List[FlintRational], symbols
     ) -> FlintMatrix:
         self.symbols = symbols
         self._rows = rows

--- a/ramanujantools/flint_core/matrix.py
+++ b/ramanujantools/flint_core/matrix.py
@@ -17,7 +17,11 @@ class FlintMatrix:
     """
 
     def __init__(
-        self, rows: int, cols: int, values: List[FlintMatrix], symbols
+        self,
+        rows: int,
+        cols: int,
+        values: List[FlintRational],
+        symbols,
     ) -> FlintMatrix:
         self.symbols = symbols
         self._rows = rows
@@ -25,24 +29,29 @@ class FlintMatrix:
         self.values = values
 
     @staticmethod
-    def from_sympy(matrix: Matrix, symbols=None) -> FlintMatrix:
+    def from_sympy(matrix: Matrix, symbols=None, fmpz=True) -> FlintMatrix:
         """
         Converts a Matrix to FlintMatrix.
+        Args:
+            matrix: The matrix as ramanujantools.Matrix
+            symbols: The symbols this matrix supports
+            fmpz: decide between fmpq (supports rational subs) and fmpz (faster but only integer subs).
         """
         symbols = [str(symbol) for symbol in symbols or matrix.free_symbols]
-        values = [FlintRational.from_sympy(cell, symbols) for cell in matrix]
+        values = [FlintRational.from_sympy(cell, symbols, fmpz) for cell in matrix]
         return FlintMatrix(matrix.rows, matrix.cols, values, symbols)
 
     @staticmethod
-    def eye(N: int, symbols) -> FlintMatrix:
+    def eye(N: int, symbols, fmpz=True) -> FlintMatrix:
         """
         Creates an identity matrix of size N.
 
         Args:
             N: The squared matrix dimension
             symbols: The symbols this matrix supports
+            fmpz: decide between fmpq (supports rational subs) and fmpz (faster but only integer subs).
         """
-        values = [FlintRational.from_sympy(sp.simplify(0), symbols)] * N**2
+        values = [FlintRational.from_sympy(sp.simplify(0), symbols, fmpz=fmpz)] * N**2
         current = 0
         while current < N**2:
             values[current] += 1
@@ -204,7 +213,9 @@ class FlintMatrix:
         position = Position(start)
         trajectory = Position(trajectory)
         results = []
-        matrix = FlintMatrix.eye(self.rows(), self.free_symbols())
+        matrix = FlintMatrix.eye(
+            self.rows(), self.free_symbols(), fmpz=position.is_polynomial()
+        )
         for depth in range(0, iterations[-1]):
             if depth in iterations:
                 results.append(matrix)

--- a/ramanujantools/flint_core/matrix_test.py
+++ b/ramanujantools/flint_core/matrix_test.py
@@ -5,8 +5,8 @@ from ramanujantools import Matrix
 from ramanujantools.flint_core import FlintMatrix
 
 
-def flintify(matrix: Matrix) -> FlintMatrix:
-    return FlintMatrix.from_sympy(matrix)
+def flintify(matrix: Matrix, fmpz=True) -> FlintMatrix:
+    return FlintMatrix.from_sympy(matrix, fmpz=fmpz)
 
 
 def test_factor():
@@ -48,3 +48,21 @@ def test_walk():
     expected = (matrix * matrix.subs({n: n + 1}) * matrix.subs({n: n + 2})).factor()
 
     assert expected == flintify(matrix).walk({n: 1}, 3, {n: n}).factor()
+
+
+def test_walk_rational():
+    matrix = Matrix(
+        [
+            [1, n**2 + n, n**2 - n + 5],
+            [3 * n + 9, n**2 - 1, 1 / (n + 1)],
+            [n**2 + 7, n - 2, (n + 1) * (n - 3)],
+        ],
+    )
+
+    expected = (
+        matrix.subs({n: n / 2})
+        * matrix.subs({n: n / 2 + 1})
+        * matrix.subs({n: n / 2 + 2})
+    ).factor()
+
+    assert expected == flintify(matrix, fmpz=False).walk({n: 1}, 3, {n: n / 2}).factor()

--- a/ramanujantools/flint_core/rational.py
+++ b/ramanujantools/flint_core/rational.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from typing import List, Dict
 
+import math
 import flint
 import sympy as sp
 
@@ -24,11 +25,9 @@ class FlintRational:
 
     @staticmethod
     def content_gcd(poly1, poly2):
-        # Currently fmpq_mpoly.gcd does not account for content (gcd of the rational coefficients)
-        # As a patch - we're using sympy which is absolutely CRAZY.
-        # https://github.com/flintlib/python-flint/issues/249
         coeffs = poly1.coeffs() + poly2.coeffs()
-        return int(sp.gcd(coeffs))
+        coeffs = [c.numerator for c in coeffs]
+        return math.gcd(*coeffs)
 
     @staticmethod
     def fmpq_from_sympy(poly: sp.Expr, ctx) -> flint.fmpq_mpoly:

--- a/ramanujantools/flint_core/rational_test.py
+++ b/ramanujantools/flint_core/rational_test.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import flint
 import sympy as sp
 from sympy.abc import x, y
@@ -5,13 +7,13 @@ from sympy.abc import x, y
 from ramanujantools.flint_core import FlintRational
 
 
-def flintify(expr: sp.Expr) -> FlintRational:
-    return FlintRational.from_sympy(expr)
+def flintify(expr: sp.Expr, symbols: List = None) -> FlintRational:
+    return FlintRational.from_sympy(expr, symbols)
 
 
 def test_from_sympy():
     expression = (x + y - 3) / (x**2 - y)
-    ctx = flint.fmpz_mpoly_ctx.get(["x", "y"], "lex")
+    ctx = flint.fmpq_mpoly_ctx.get(["x", "y"], "lex")
     _x, _y = ctx.gens()
     expected = FlintRational(_x + _y - 3, _x**2 - _y)
     assert expected == flintify(expression)
@@ -63,3 +65,15 @@ def test_eq():
 def test_factor():
     expected = (x + y) * (x**2 + y**2) * (y - 3) / ((x + 17) * (y - 15) * (x * y + 1))
     assert expected == flintify(expected.expand()).factor()
+
+
+def test_subs_integer():
+    expr = (x**2 + 3 * y / 2 - sp.Rational(5, 4)) / (x * y + y**2 / 3)
+    subs = {x: 3, y: x}
+    assert flintify(expr.subs(subs), symbols=[x, y]) == flintify(expr).subs(subs)
+
+
+def test_subs_rational():
+    expr = (x**2 + 3 * y / 2 - sp.Rational(5, 4)) / (x * y + y**2 / 3)
+    subs = {x: sp.Rational(2, 7), y: (x + 5) / 4}
+    assert flintify(expr.subs(subs), symbols=[x, y]) == flintify(expr).subs(subs)

--- a/ramanujantools/flint_core/rational_test.py
+++ b/ramanujantools/flint_core/rational_test.py
@@ -7,13 +7,13 @@ from sympy.abc import x, y
 from ramanujantools.flint_core import FlintRational
 
 
-def flintify(expr: sp.Expr, symbols: List = None) -> FlintRational:
-    return FlintRational.from_sympy(expr, symbols)
+def flintify(expr: sp.Expr, symbols: List = None, fmpz=True) -> FlintRational:
+    return FlintRational.from_sympy(expr, symbols, fmpz)
 
 
 def test_from_sympy():
     expression = (x + y - 3) / (x**2 - y)
-    ctx = flint.fmpq_mpoly_ctx.get(["x", "y"], "lex")
+    ctx = flint.fmpz_mpoly_ctx.get(["x", "y"], "lex")
     _x, _y = ctx.gens()
     expected = FlintRational(_x + _y - 3, _x**2 - _y)
     assert expected == flintify(expression)
@@ -76,4 +76,6 @@ def test_subs_integer():
 def test_subs_rational():
     expr = (x**2 + 3 * y / 2 - sp.Rational(5, 4)) / (x * y + y**2 / 3)
     subs = {x: sp.Rational(2, 7), y: (x + 5) / 4}
-    assert flintify(expr.subs(subs), symbols=[x, y]) == flintify(expr).subs(subs)
+    assert flintify(expr.subs(subs), symbols=[x, y], fmpz=False) == flintify(
+        expr, fmpz=False
+    ).subs(subs)

--- a/ramanujantools/matrix.py
+++ b/ramanujantools/matrix.py
@@ -83,11 +83,7 @@ class Matrix(sp.Matrix):
         subbed_in = trajectory.free_symbols().union(start.free_symbols())
         subbed_out = set(trajectory.keys()).union(set(start.keys()))
 
-        return (
-            (self.free_symbols - subbed_out).union(subbed_in) != set()
-            and trajectory.is_polynomial()
-            and start.is_polynomial()
-        )
+        return (self.free_symbols - subbed_out).union(subbed_in) != set()
 
     def _can_call_numerical_subs(self, substitutions: Dict) -> bool:
         """

--- a/ramanujantools/matrix_test.py
+++ b/ramanujantools/matrix_test.py
@@ -58,8 +58,8 @@ def test_can_call_flint_walk():
     # x remains a symbol
     assert m._can_call_flint_walk({x: 1, y: 1}, {x: x, y: 1})
 
-    # currently not supporting rational coefficients of symbolic polynomials
-    assert not m._can_call_flint_walk({x: 1, y: 1}, {x: x / 2, y: 1})
+    # rational coefficients of symbolic polynomials are supported
+    assert m._can_call_flint_walk({x: 1, y: 1}, {x: x / 2, y: 1})
 
     # substituting a different symbol causes symbolic flint calculation
     assert m._can_call_flint_walk({x: 1, y: 1}, {x: n - 1, y: n**2})

--- a/ramanujantools/position.py
+++ b/ramanujantools/position.py
@@ -76,7 +76,7 @@ class Position(dict):
 
     def is_polynomial(self) -> bool:
         """
-        Returns true iff all position elements are numerical
+        Returns true iff all position elements are polynomial
         """
         for element in self.values():
             if not all(

--- a/ramanujantools/position.py
+++ b/ramanujantools/position.py
@@ -88,6 +88,16 @@ class Position(dict):
                 return False
         return True
 
+    def denominator_lcm(self) -> int:
+        r"""
+        Returns the lcm of all denominators
+        """
+        return int(
+            sp.lcm(
+                [sp.simplify(element).as_numer_denom()[1] for element in self.values()]
+            )
+        )
+
     def is_integer(self) -> bool:
         """
         Returns true iff all position elements are numerical

--- a/ramanujantools/position_test.py
+++ b/ramanujantools/position_test.py
@@ -83,5 +83,12 @@ def test_is_polynomial():
     assert not Position({x: sp.Rational(1, 2), y: 1}).is_polynomial()
 
 
+def test_is_denominator_lcm():
+    assert 1 == Position({x: 1, y: 7}).denominator_lcm()
+    assert 1 == Position({x: 1, y: x**2 + 3 * x + 1}).denominator_lcm()
+    assert 2 == Position({x: x / 2, y: x**2 + 3 * x + 1}).denominator_lcm()
+    assert 15 == Position({x: sp.Rational(1, 3), y: x / 5}).denominator_lcm()
+
+
 def test_free_symbols():
     assert {x, z} == Position({x: 1, y: z, z: x}).free_symbols()


### PR DESCRIPTION
Added flint support for rational starting positions in CMF.trajectory_matrix.
In order to achieve this, the classes FlintRational and FlintMatrix are now available in two flavors: integer (which we had up until one) which uses `fmpz_mpoly`, and rational which uses `fmpq_mpoly`.

Benchmarks on clean master, before changes:
![image](https://github.com/user-attachments/assets/78d3c485-35ce-44a9-881b-0f66725eb7b1)

Benchmarks after the changes in this PR (note the extra 3f2 rational benchmark):
![image](https://github.com/user-attachments/assets/e739391a-4224-4eb4-ac7d-981daddcf5da)

