### PR TITLE
optimize/trajectory-caching

### DIFF
--- a/ramanujantools/cmf/cmf.py
+++ b/ramanujantools/cmf/cmf.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from typing import Dict, List, Optional, Set
+from functools import lru_cache
 
 import itertools
 from multimethod import multimethod
@@ -43,6 +44,9 @@ class CMF:
         self.assert_matrices_same_dimension()
         if validate:
             self.assert_conserving()
+
+    def __hash__(self) -> int:
+        return hash(frozenset(self.matrices.items()))
 
     def __eq__(self, other) -> bool:
         return self.matrices == other.matrices
@@ -167,6 +171,7 @@ class CMF:
             }
         )
 
+    @lru_cache
     def _calculate_diagonal_matrix(
         self, trajectory: Position, start: Position
     ) -> Matrix:

--- a/ramanujantools/matrix_benchmark.py
+++ b/ramanujantools/matrix_benchmark.py
@@ -62,4 +62,4 @@ def test_as_companion_3x3_2f2_benchmark(benchmark):
             [-2 * n - 1, -(n**2) + n + 1, (3 * n + 2) * (3 * n + 4)],
         ]
     )
-    benchmark(Matrix.as_companion, matrix, inflate_all=False)
+    benchmark(Matrix.as_companion, matrix)

--- a/ramanujantools/matrix_benchmark.py
+++ b/ramanujantools/matrix_benchmark.py
@@ -3,14 +3,19 @@ from sympy.abc import n
 from ramanujantools import Matrix
 
 
+def walk_benchmark(matrix, trajectory, iterations, start):
+    Matrix._walk_inner.cache_clear()
+    return matrix.walk(trajectory, iterations, start)
+
+
 def test_walk_pcf_single_parameter_benchmark(benchmark):
     matrix = Matrix([[0, -(n**2)], [1, n + 1]])
-    benchmark(Matrix.walk, matrix, {n: 1}, 1000, {n: 1})
+    benchmark(walk_benchmark, matrix, {n: 1}, 1000, {n: 1})
 
 
 def test_walk_2x2_single_parameter_benchmark(benchmark):
     matrix = Matrix([[n**3 - 1, -(n**2)], [n**2 + 17, 1 / (n + 1)]])
-    benchmark(Matrix.walk, matrix, {n: 1}, 1000, {n: 1})
+    benchmark(walk_benchmark, matrix, {n: 1}, 1000, {n: 1})
 
 
 def test_walk_3x3_single_parameter_benchmark(benchmark):
@@ -21,7 +26,7 @@ def test_walk_3x3_single_parameter_benchmark(benchmark):
             [1 / (n + 2), 12 * n**2 + 13 * n + 14 * n, 19],
         ]
     )
-    benchmark(Matrix.walk, matrix, {n: 1}, 1000, {n: 1})
+    benchmark(walk_benchmark, matrix, {n: 1}, 1000, {n: 1})
 
 
 def test_walk_5x5_single_parameter_benchmark(benchmark):
@@ -34,7 +39,7 @@ def test_walk_5x5_single_parameter_benchmark(benchmark):
             [n, n**2, n**3, 1 - n, -n * (n - 7) + 3],
         ]
     )
-    benchmark(Matrix.walk, matrix, {n: 1}, 1000, {n: 1})
+    benchmark(walk_benchmark, matrix, {n: 1}, 1000, {n: 1})
 
 
 def test_walk_5x5_polynomial_single_parameter_benchmark(benchmark):
@@ -47,7 +52,7 @@ def test_walk_5x5_polynomial_single_parameter_benchmark(benchmark):
             [n, n**2, n**3, 1 - n, -n * (n - 7) + 3],
         ]
     )
-    benchmark(Matrix.walk, matrix, {n: 1}, 1000, {n: 1})
+    benchmark(walk_benchmark, matrix, {n: 1}, 1000, {n: 1})
 
 
 def test_as_companion_3x3_2f2_benchmark(benchmark):

--- a/ramanujantools/position.py
+++ b/ramanujantools/position.py
@@ -52,6 +52,9 @@ class Position(dict):
     def __neg__(self):
         return -1 * self
 
+    def __hash__(self):
+        return hash(frozenset(self.items()))
+
     def copy(self):
         return Position(super().copy())
 


### PR DESCRIPTION
Add caching to CMF._calculate_diagonal_matrix and Matrix.walk to boost trajectory matrix calculations

CMF benchmarks:
before:
![image](https://github.com/user-attachments/assets/99b4c849-21f1-42ef-961e-f58252e1ec18)

after:
![image](https://github.com/user-attachments/assets/281356ef-4d25-4884-b04a-cebed82051a1)

Matrix benchmarks are unchanged.
