### PR TITLE
Optimize/full-flint-trajectories

### DIFF
--- a/ramanujantools/cmf/cmf.py
+++ b/ramanujantools/cmf/cmf.py
@@ -226,6 +226,9 @@ class CMF:
         symbol: sp.Symbol,
         ctx: FlintContext,
     ) -> FlintMatrix:
+        """
+        Internal trajectory matrix logic, used for type conversions. Do not use directly.
+        """
         start = (
             CMF.variable_reduction_substitution(trajectory, start, symbol)
             if start is not None
@@ -307,12 +310,15 @@ class CMF:
 
     def _walk_inner(
         self,
-        trajectory: Dict,
+        trajectory: Position,
         iterations: List[int],
-        start: Dict,
+        start: Position,
         symbol: sp.Symbol,
         ctx: FlintContext,
     ) -> List[FlintMatrix]:
+        """
+        Internal walk logic, used for type conversions. Do not use directly.
+        """
         trajectory_matrix = self._trajectory_matrix_inner(
             trajectory, start, symbol, ctx
         )

--- a/ramanujantools/cmf/cmf.py
+++ b/ramanujantools/cmf/cmf.py
@@ -9,7 +9,7 @@ import sympy as sp
 from sympy.abc import n
 
 from ramanujantools import Position, Matrix, Limit, simplify
-from ramanujantools.flint_core import FlintMatrix
+from ramanujantools.flint_core import FlintMatrix, FlintContext, mpoly_ctx
 
 
 class CMF:
@@ -104,6 +104,22 @@ class CMF:
                     f"M({symbol}) is of dimension {matrix.rows}x{matrix.cols}, expected {expected_N}x{expected_N}"
                 )
 
+    @staticmethod
+    def inner_symbol(symbol: sp.Symbol) -> sp.Symbol:
+        """
+        Returns the inner symbol used in calculations, based on the symbol used.
+        """
+        return sp.Symbol(f"{symbol}_inner")
+
+    def ctx(self, symbol: sp.Symbol, start: Optional[Position]) -> FlintContext:
+        start = Position(start) if start else Position()
+        free_symbols = (
+            self.free_symbols()
+            .union({symbol, CMF.inner_symbol(symbol)})
+            .union(start.free_symbols())
+        )
+        return mpoly_ctx(free_symbols, fmpz=start.is_polynomial())
+
     def M(self, axis: sp.Symbol, sign: bool = True) -> Matrix:
         """
         Returns the axis matrix for a given axis.
@@ -174,7 +190,7 @@ class CMF:
 
     @lru_cache
     def _calculate_diagonal_matrix(
-        self, trajectory: Position, start: Position, symbols: Set
+        self, trajectory: Position, start: Position, ctx: FlintContext
     ) -> FlintMatrix:
         """
         The manual calculation of trajectory matrix in the stopping condition.
@@ -193,44 +209,42 @@ class CMF:
             )
 
         position = start.copy()
-        fmpz = position.is_polynomial()
-        result = FlintMatrix.eye(self.N(), symbols, fmpz=fmpz)
+        result = FlintMatrix.eye(self.N(), ctx)
         for axis in self.axes_sorter(self.axes(), trajectory, start):
             if trajectory[axis] == 0:
                 continue
             sign = trajectory[axis] >= 0
             current = self.M(axis, sign)
-            result *= FlintMatrix.from_sympy(current, symbols, fmpz).subs(position)
+            result *= FlintMatrix.from_sympy(current, ctx).subs(position)
             position[axis] += trajectory[axis]
         return result
 
     def _trajectory_matrix_inner(
-        self, trajectory: Dict, start: Dict = None, symbol=n
+        self,
+        trajectory: Position,
+        start: Position,
+        symbol: sp.Symbol,
+        ctx: FlintContext,
     ) -> FlintMatrix:
-        trajectory = Position(trajectory)
-        position = (
+        start = (
             CMF.variable_reduction_substitution(trajectory, start, symbol)
             if start is not None
             else Position({axis: axis for axis in self.axes()})
         )
 
-        free_symbols = self.free_symbols().union(position.free_symbols())
-
         # Stopping condition: l-infinity norm of trajectory is less than 1
         if trajectory.longest() <= 1:
-            return self._calculate_diagonal_matrix(
-                trajectory, position, frozenset(free_symbols)
-            )
+            return self._calculate_diagonal_matrix(trajectory, start, ctx)
 
-        inner_symbol = sp.Symbol(f"{symbol}_inner")
-        free_symbols.add(inner_symbol)
-
-        fmpz = position.is_polynomial()
-        result = FlintMatrix.eye(self.N(), free_symbols, fmpz=fmpz)
+        result = FlintMatrix.eye(self.N(), ctx)
+        inner_symbol = CMF.inner_symbol(symbol)
         depth = trajectory.shortest()
+        position = start.copy()
         while depth > 0:
             diagonal = trajectory.signs()
-            result *= self._walk_inner(diagonal, int(depth), position, inner_symbol)
+            result *= self._walk_inner(
+                diagonal, int(depth), position, inner_symbol, ctx
+            )
             position += depth * diagonal
             trajectory -= depth * diagonal
             depth = trajectory.shortest()
@@ -261,7 +275,9 @@ class CMF:
                 f"Start axes {start.keys()} do not match CMF axes {self.axes()}"
             )
 
-        return self._trajectory_matrix_inner(trajectory, start, symbol).factor()
+        return self._trajectory_matrix_inner(
+            Position(trajectory), start, symbol, self.ctx(symbol, start)
+        ).factor()
 
     @staticmethod
     def variable_reduction_substitution(
@@ -294,10 +310,11 @@ class CMF:
         trajectory: Dict,
         iterations: List[int],
         start: Dict,
-        symbol=sp.Symbol("walk"),
+        symbol: sp.Symbol,
+        ctx: FlintContext,
     ) -> List[FlintMatrix]:
         trajectory_matrix = self._trajectory_matrix_inner(
-            trajectory, start, symbol=symbol
+            trajectory, start, symbol, ctx
         )
         return trajectory_matrix.walk({symbol: 1}, iterations, {symbol: 1})
 
@@ -334,8 +351,13 @@ class CMF:
             raise ValueError(
                 f"iterations must contain only non-negative values, got {iterations}"
             )
+
+        trajectory = Position(trajectory)
+        start = Position(start)
+        ctx = self.ctx(symbol, start)
         return [
-            m.factor() for m in self._walk_inner(trajectory, iterations, start, symbol)
+            m.factor()
+            for m in self._walk_inner(trajectory, iterations, start, symbol, ctx)
         ]
 
     @multimethod

--- a/ramanujantools/cmf/cmf_benchmark.py
+++ b/ramanujantools/cmf/cmf_benchmark.py
@@ -80,3 +80,12 @@ def test_trajectory_matrix_4f3_huge(benchmark):
     trajectory = {x0: -1, x1: 1, x2: 2, x3: -2, y0: 3, y1: 7, y2: 4}
     start = trajectory
     benchmark(CMF.trajectory_matrix, cmf, trajectory, start)
+
+
+def test_walk_4f3(benchmark):
+    x0, x1, x2, x3 = sp.symbols("x:4")
+    y0, y1, y2 = sp.symbols("y:3")
+    cmf = pFq(4, 3, 1)
+    start = {x0: 1, x1: 1, x2: 2, x3: 2, y0: 3, y1: 3, y2: 4}
+    trajectory = {x0: 1, x1: 1, x2: 2, x3: 2, y0: 3, y1: 3, y2: 4}
+    benchmark(CMF.walk, cmf, trajectory, 1000, start)

--- a/ramanujantools/flint_core/__init__.py
+++ b/ramanujantools/flint_core/__init__.py
@@ -1,4 +1,5 @@
+from .context import mpoly_ctx, FlintPoly, FlintContext
 from .rational import FlintRational
 from .matrix import FlintMatrix
 
-__all__ = ["FlintRational", "FlintMatrix"]
+__all__ = ["FlintRational", "FlintMatrix", "mpoly_ctx", "FlintPoly", "FlintContext"]

--- a/ramanujantools/flint_core/context.py
+++ b/ramanujantools/flint_core/context.py
@@ -8,6 +8,12 @@ FlintPoly: TypeAlias = flint.fmpz_mpoly | flint.fmpq_mpoly_ctx
 
 
 def mpoly_ctx(symbols: List[sp.Symbol], fmpz: bool) -> FlintContext:
+    """
+    Creates a FlintContext
+    Args:
+        symbols: The symbols to be supported by the FlintContext
+        fmpz: if True, returns fmpz_mpoly_ctx. Otherwise returns fmpq_mpoly_ctx.
+    """
     ctx_type = flint.fmpz_mpoly_ctx if fmpz else flint.fmpq_mpoly_ctx
     return ctx_type.get(
         [str(symbol) for symbol in list(sorted(symbols, key=str))], "lex"

--- a/ramanujantools/flint_core/context.py
+++ b/ramanujantools/flint_core/context.py
@@ -1,0 +1,14 @@
+from typing import List, TypeAlias
+
+import flint
+import sympy as sp
+
+FlintContext: TypeAlias = flint.fmpz_mpoly_ctx | flint.fmpq_mpoly_ctx
+FlintPoly: TypeAlias = flint.fmpz_mpoly | flint.fmpq_mpoly_ctx
+
+
+def mpoly_ctx(symbols: List[sp.Symbol], fmpz: bool) -> FlintContext:
+    ctx_type = flint.fmpz_mpoly_ctx if fmpz else flint.fmpq_mpoly_ctx
+    return ctx_type.get(
+        [str(symbol) for symbol in list(sorted(symbols, key=str))], "lex"
+    )

--- a/ramanujantools/flint_core/matrix_test.py
+++ b/ramanujantools/flint_core/matrix_test.py
@@ -2,11 +2,12 @@ import sympy as sp
 from sympy.abc import n
 
 from ramanujantools import Matrix
-from ramanujantools.flint_core import FlintMatrix
+from ramanujantools.flint_core import mpoly_ctx, FlintMatrix
 
 
 def flintify(matrix: Matrix, fmpz=True) -> FlintMatrix:
-    return FlintMatrix.from_sympy(matrix, fmpz=fmpz)
+    ctx = mpoly_ctx(matrix.free_symbols, fmpz)
+    return FlintMatrix.from_sympy(matrix, ctx)
 
 
 def test_factor():
@@ -46,7 +47,6 @@ def test_walk():
     )
 
     expected = (matrix * matrix.subs({n: n + 1}) * matrix.subs({n: n + 2})).factor()
-
     assert expected == flintify(matrix).walk({n: 1}, 3, {n: n}).factor()
 
 

--- a/ramanujantools/flint_core/rational_test.py
+++ b/ramanujantools/flint_core/rational_test.py
@@ -1,21 +1,21 @@
 from typing import List
 
-import flint
 import sympy as sp
 from sympy.abc import x, y
 
-from ramanujantools.flint_core import FlintRational
+from ramanujantools.flint_core import mpoly_ctx, FlintRational
 
 
 def flintify(expr: sp.Expr, symbols: List = None, fmpz=True) -> FlintRational:
-    return FlintRational.from_sympy(expr, symbols, fmpz)
+    ctx = mpoly_ctx(symbols or list(expr.free_symbols), fmpz)
+    return FlintRational.from_sympy(expr, ctx)
 
 
 def test_from_sympy():
     expression = (x + y - 3) / (x**2 - y)
-    ctx = flint.fmpz_mpoly_ctx.get(["x", "y"], "lex")
+    ctx = mpoly_ctx(["x", "y"], fmpz=True)
     _x, _y = ctx.gens()
-    expected = FlintRational(_x + _y - 3, _x**2 - _y)
+    expected = FlintRational(_x + _y - 3, _x**2 - _y, ctx)
     assert expected == flintify(expression)
 
 

--- a/ramanujantools/matrix.py
+++ b/ramanujantools/matrix.py
@@ -296,29 +296,6 @@ class Matrix(sp.Matrix):
         """
         from ramanujantools.flint_core import FlintMatrix
 
-        if not self.is_square():
-            raise ValueError(
-                f"Matrix.walk is only supported for square matrices, got a {self.rows}x{self.cols} matrix"
-            )
-
-        if start.keys() != trajectory.keys():
-            raise ValueError(
-                f"`start` and `trajectory` must contain same keys, got "
-                f"start={set(start.keys())}, trajectory={set(trajectory.keys())}"
-            )
-
-        iterations_set = set(iterations)
-        if len(iterations_set) != len(iterations):
-            raise ValueError(f"`iterations` values must be unique, got {iterations}")
-
-        if not iterations == tuple(sorted(iterations)):
-            raise ValueError(f"Iterations must be sorted, got {iterations}")
-
-        if not all(depth >= 0 for depth in iterations):
-            raise ValueError(
-                f"iterations must contain only non-negative values, got {iterations}"
-            )
-
         if self._can_call_flint_walk(trajectory, start):
             symbols = self.walk_free_symbols(start)
             as_flint = FlintMatrix.from_sympy(self, symbols)
@@ -365,6 +342,29 @@ class Matrix(sp.Matrix):
                         if `start` and `trajectory` have different keys,
                         if `iterations` contains duplicate values
         """
+        if not self.is_square():
+            raise ValueError(
+                f"Matrix.walk is only supported for square matrices, got a {self.rows}x{self.cols} matrix"
+            )
+
+        if start.keys() != trajectory.keys():
+            raise ValueError(
+                f"`start` and `trajectory` must contain same keys, got "
+                f"start={set(start.keys())}, trajectory={set(trajectory.keys())}"
+            )
+
+        iterations_set = set(iterations)
+        if len(iterations_set) != len(iterations):
+            raise ValueError(f"`iterations` values must be unique, got {iterations}")
+
+        if not iterations == sorted(iterations):
+            raise ValueError(f"Iterations must be sorted, got {iterations}")
+
+        if not all(depth >= 0 for depth in iterations):
+            raise ValueError(
+                f"iterations must contain only non-negative values, got {iterations}"
+            )
+
         return self._walk_inner(
             Position(trajectory), tuple(iterations), Position(start)
         )

--- a/ramanujantools/matrix.py
+++ b/ramanujantools/matrix.py
@@ -10,6 +10,7 @@ import sympy as sp
 from sympy.abc import n
 
 from ramanujantools import Position
+from ramanujantools.flint_core import mpoly_ctx, FlintMatrix
 
 
 class Matrix(sp.Matrix):
@@ -186,9 +187,9 @@ class Matrix(sp.Matrix):
         return Matrix(sp.simplify(self))
 
     def factor(self) -> Matrix:
-        from ramanujantools.flint_core import FlintMatrix
-
-        return FlintMatrix.from_sympy(self, self.free_symbols).factor()
+        return FlintMatrix.from_sympy(
+            self, mpoly_ctx(self.free_symbols, fmpz=True)
+        ).factor()
 
     def singular_points(self) -> List[Dict]:
         r"""
@@ -298,7 +299,9 @@ class Matrix(sp.Matrix):
 
         if self._can_call_flint_walk(trajectory, start):
             symbols = self.walk_free_symbols(start)
-            as_flint = FlintMatrix.from_sympy(self, symbols)
+            as_flint = FlintMatrix.from_sympy(
+                self, mpoly_ctx(symbols, fmpz=start.is_polynomial())
+            )
             results = as_flint.walk(trajectory, list(iterations), start)
             results = [result.factor() for result in results]
             return results
@@ -364,7 +367,6 @@ class Matrix(sp.Matrix):
             raise ValueError(
                 f"iterations must contain only non-negative values, got {iterations}"
             )
-
         return self._walk_inner(
             Position(trajectory), tuple(iterations), Position(start)
         )


### PR DESCRIPTION
Make CMF.trajectory_matrix calculate the whole thing in flint, without converting to sympy up to the end.

Before:
![image](https://github.com/user-attachments/assets/98271abd-59f5-4bd8-8e8c-81096e29784f)

After:
![image](https://github.com/user-attachments/assets/3601a2d1-ffb7-43e4-9695-ba7d0eac8ec8)
