### PR TITLE
Feature/minimal-recursion

### DIFF
--- a/ramanujantools/matrix.py
+++ b/ramanujantools/matrix.py
@@ -283,7 +283,17 @@ class Matrix(sp.Matrix):
         Args:
             inflate_all: if True, will greedily inflate the companion form matrix until it's polynomial.
         """
-        return self.coboundary(self.companion_coboundary_matrix())
+        U = self.companion_coboundary_matrix()
+        rank = U.rank()
+        if rank == self.rows:
+            return self.coboundary(self.companion_coboundary_matrix())
+        else:
+            symbols = sp.symbols(f"c:{rank}")
+            variables = Matrix(symbols + (-1,))
+            truncated = U[:, : rank + 1]
+            solutions = sp.solve(truncated * variables, symbols)
+            elements = [solutions[symbol] for symbol in symbols]
+            return Matrix.companion_form(elements)
 
     @lru_cache
     def _walk_inner(

--- a/ramanujantools/matrix.py
+++ b/ramanujantools/matrix.py
@@ -204,7 +204,7 @@ class Matrix(sp.Matrix):
 
     def coboundary(self, U: Matrix, symbol: sp.Symbol = n) -> Matrix:
         r"""
-        Calculates the coboundary relation of M and U $U(n) * M(n) * U^{-1}(n+1)$, where $M$ is `self`.
+        Calculates the coboundary relation of M and U $U^{-1}(n) * M(n) * U^(n+1)$, where $M$ is `self`.
 
         Args:
             U: The coboundary matrix
@@ -212,7 +212,7 @@ class Matrix(sp.Matrix):
         Returns:
             The coboundary relation as described above
         """
-        return (U * self * U.inverse().subs({symbol: symbol + 1})).simplify()
+        return (U.inverse() * self * U.subs({symbol: symbol + 1})).simplify()
 
     def companion_coboundary_matrix(self, symbol: sp.Symbol = n) -> Matrix:
         r"""
@@ -226,7 +226,7 @@ class Matrix(sp.Matrix):
         vectors = [e1]
         for i in range(1, N):
             vectors.append(self * vectors[i - 1].subs({symbol: symbol + 1}))
-        return Matrix.hstack(*vectors).inverse().simplify()
+        return Matrix.hstack(*vectors).simplify()
 
     @staticmethod
     def companion_form(values: List[sp.Expr]) -> Matrix:

--- a/ramanujantools/matrix_test.py
+++ b/ramanujantools/matrix_test.py
@@ -124,7 +124,7 @@ def test_singular_points_multi_variable():
 def test_coboundary():
     m = Matrix([[1, n, 2], [3, n**2, 5 * n], [n - 7, n**2 + 1, n - 3]])
     U = Matrix([[3, 1, n - 2], [5, n**2 - 3 * n + 1, 0], [11 * n + 2, 3, n - 19]])
-    expected = U * m * U.inverse().subs({n: n + 1})
+    expected = U.inverse() * m * U.subs({n: n + 1})
     assert expected == m.coboundary(U)
 
 

--- a/ramanujantools/matrix_test.py
+++ b/ramanujantools/matrix_test.py
@@ -4,6 +4,7 @@ import sympy as sp
 from sympy.abc import x, y, n
 
 from ramanujantools import Matrix, Limit, simplify
+from ramanujantools.pcf import PCF
 from ramanujantools.cmf.known_cmfs import pFq
 
 
@@ -166,6 +167,24 @@ def test_as_companion():
 
     companion = m.as_companion()
     assert companion.is_companion()
+
+
+def test_as_companion_smaller_recursion():
+    # This matrix is derived from pFq(4, 3, 1) with
+    # start = {x0: 0, x1: 0, x2: 1, x3: 1, y0: 1, y1: 1, y2: 1},
+    # trajectory = {x0: -1, x1: -1, x2: 1, x3: 1, y0: 0, y1: 0, y2: 0}
+    m = Matrix(
+        [
+            [(17 * n - 12) / n, 12 * n - 8, 4 * n * (2 * n - 1)],
+            [(24 * n - 24) / n**2, (17 * n - 16) / n, 12 * n - 8],
+            [-12 / n**3, -8 / n**2, (n - 4) / n],
+        ]
+    )
+    companion = m.as_companion()
+    assert companion.is_companion()
+    assert 2 == companion.rows
+    # This is Apery's PCF
+    assert companion.as_pcf().pcf == PCF(34 * n**3 + 51 * n**2 + 27 * n + 5, -(n**6))
 
 
 def test_companion_coboundary_two_variables():


### PR DESCRIPTION
Allow as_companion to return a smaller recursion in a case of linear dependency.

This pull request also swaps the coboundary inverse order.