### PR TITLE
refactor/numerical-walk-with-flint

### DIFF
--- a/ramanujantools/matrix_test.py
+++ b/ramanujantools/matrix_test.py
@@ -31,39 +31,22 @@ def test_reduce():
     assert m.reduce() == initial
 
 
-def test_can_call_numerical_subs():
+def test_is_numeric_walk():
     m = Matrix([[x, 1], [y, 2]])
 
-    # not enough parameters
-    assert not m._can_call_numerical_subs({x: 1})
-
-    # some parameters are not integer
-    assert not m._can_call_numerical_subs({x: 1, y: y})
-    assert not m._can_call_numerical_subs({x: 1, y: sp.Rational(2, 3)})
-
-    # rational matrix
-    assert not (m / x)._can_call_numerical_subs({x: 1, y: 1})
-
-    assert m._can_call_numerical_subs({x: 17, y: 31})
-
-
-def test_can_call_flint_walk():
-    m = Matrix([[x, 1], [y, 2]])
-
-    # flint is slow for numerical walk (both integer and rational)
-    assert not m._can_call_flint_walk({x: 1, y: 1}, {x: 1, y: 1})
-    assert not m._can_call_flint_walk(
+    assert m._is_numeric_walk({x: 1, y: 1}, {x: 1, y: 1})
+    assert m._is_numeric_walk(
         {x: 1, y: 1}, {x: sp.Rational(1, 2), y: sp.Rational(1, 2)}
     )
 
     # x remains a symbol
-    assert m._can_call_flint_walk({x: 1, y: 1}, {x: x, y: 1})
+    assert not m._is_numeric_walk({x: 1, y: 1}, {x: x, y: 1})
 
     # rational coefficients of symbolic polynomials are supported
-    assert m._can_call_flint_walk({x: 1, y: 1}, {x: x / 2, y: 1})
+    assert not m._is_numeric_walk({x: 1, y: 1}, {x: x / 2, y: 1})
 
     # substituting a different symbol causes symbolic flint calculation
-    assert m._can_call_flint_walk({x: 1, y: 1}, {x: n - 1, y: n**2})
+    assert not m._is_numeric_walk({x: 1, y: 1}, {x: n - 1, y: n**2})
 
 
 def test_subs_degenerated():
@@ -83,12 +66,6 @@ def test_subs_symbolic():
     m = Matrix([[x, x**2, 13 + x, -x]])
     expr = y**2 + x - 3
     assert Matrix([[expr, (expr) ** 2, 13 + expr, -expr]]) == m.subs({x: expr})
-
-
-def test_subs_numerical_equivalent_to_symbolic():
-    m = Matrix([[x, x**2], [13 + x, -x]])
-    substitutions = {x: 5}
-    assert m.xreplace(substitutions) == m.numerical_subs(substitutions)
 
 
 def test_as_polynomial():

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ multimethod>=1.10
 pytest>=8.2.0
 numpy>=2.0.0
 mpmath>=1.3.0
-sympy>=1.11.1
+sympy>=1.13.3
 gmpy2>=2.1.5
 python-flint>=0.7.0a5


### PR DESCRIPTION
Make numerical walk work with flint.fmpq_mat.

Performance before:
![image](https://github.com/user-attachments/assets/70130283-2824-4daa-9423-b0d9efa899aa)


Performance after:
![image](https://github.com/user-attachments/assets/dfa08519-cd43-4367-bc8b-6c28f02b4e9f)
