### PR TITLE
Refactor/numeric-matrix

### DIFF
--- a/ramanujantools/cmf/cmf.py
+++ b/ramanujantools/cmf/cmf.py
@@ -9,7 +9,7 @@ import sympy as sp
 from sympy.abc import n
 
 from ramanujantools import Position, Matrix, Limit, simplify
-from ramanujantools.flint_core import FlintMatrix, FlintContext, mpoly_ctx
+from ramanujantools.flint_core import SymbolicMatrix, FlintContext, mpoly_ctx
 
 
 class CMF:
@@ -196,20 +196,20 @@ class CMF:
 
     def _calculate_diagonal_matrix_backtrack(
         self, trajectory: Position, start: Position, ctx: FlintContext
-    ) -> FlintMatrix:
+    ) -> SymbolicMatrix:
         """
         Inner function of an inner function. DO NOT USE DIRECTLY.
         This is the backtracking hook used for `_calculate_diagonal_marix`.
         It's used to look for a non-singular path towards the trajectroy matrix.
         """
         if trajectory.longest() == 0:
-            return FlintMatrix.eye(self.N(), ctx)
+            return SymbolicMatrix.eye(self.N(), ctx)
         for axis in sorted(trajectory.keys(), key=str):
             try:
                 inner_trajectory = trajectory.copy()
                 position = start.copy()
                 sign = inner_trajectory[axis] >= 0
-                current = FlintMatrix.from_sympy(self.M(axis, sign), ctx).subs(position)
+                current = SymbolicMatrix.from_sympy(self.M(axis, sign), ctx).subs(position)
                 position[axis] += inner_trajectory.pop(axis)
                 return current * self._calculate_diagonal_matrix_backtrack(
                     inner_trajectory, position, ctx
@@ -223,7 +223,7 @@ class CMF:
     @lru_cache
     def _calculate_diagonal_matrix(
         self, trajectory: Position, start: Position, ctx: FlintContext
-    ) -> FlintMatrix:
+    ) -> SymbolicMatrix:
         """
         The manual calculation of trajectory matrix in the stopping condition.
         You should probably use `trajectory_matrix` instead.
@@ -251,7 +251,7 @@ class CMF:
         start: Position,
         symbol: sp.Symbol,
         ctx: FlintContext,
-    ) -> FlintMatrix:
+    ) -> SymbolicMatrix:
         """
         Internal trajectory matrix logic, used for type conversions. Do not use directly.
         """
@@ -265,7 +265,7 @@ class CMF:
         if trajectory.longest() <= 1:
             return self._calculate_diagonal_matrix(trajectory, start, ctx)
 
-        result = FlintMatrix.eye(self.N(), ctx)
+        result = SymbolicMatrix.eye(self.N(), ctx)
         inner_symbol = CMF.inner_symbol(symbol)
         depth = trajectory.shortest()
         position = start.copy()
@@ -341,7 +341,7 @@ class CMF:
         start: Position,
         symbol: sp.Symbol,
         ctx: FlintContext,
-    ) -> List[FlintMatrix]:
+    ) -> List[SymbolicMatrix]:
         """
         Internal walk logic for symbolic calculations. Do not use directly.
         """

--- a/ramanujantools/flint_core/__init__.py
+++ b/ramanujantools/flint_core/__init__.py
@@ -1,13 +1,13 @@
 from .context import mpoly_ctx, FlintPoly, FlintContext
 from .rational import FlintRational
-from .matrix import FlintMatrix
+from .symbolic_matrix import SymbolicMatrix
 from .numeric_matrix import NumericMatrix
 
 __all__ = [
-    "FlintRational",
-    "FlintMatrix",
     "mpoly_ctx",
     "FlintPoly",
+    "FlintRational",
     "FlintContext",
+    "SymbolicMatrix",
     "NumericMatrix",
 ]

--- a/ramanujantools/flint_core/__init__.py
+++ b/ramanujantools/flint_core/__init__.py
@@ -1,5 +1,13 @@
 from .context import mpoly_ctx, FlintPoly, FlintContext
 from .rational import FlintRational
 from .matrix import FlintMatrix
+from .numeric_matrix import NumericMatrix
 
-__all__ = ["FlintRational", "FlintMatrix", "mpoly_ctx", "FlintPoly", "FlintContext"]
+__all__ = [
+    "FlintRational",
+    "FlintMatrix",
+    "mpoly_ctx",
+    "FlintPoly",
+    "FlintContext",
+    "NumericMatrix",
+]

--- a/ramanujantools/flint_core/numeric_matrix.py
+++ b/ramanujantools/flint_core/numeric_matrix.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Callable, Dict, List
 
-from flint import fmpq_mat, fmpq
+from flint import fmpq_mat, fmpq  # noqa: F401
 from sympy.utilities.lambdify import lambdastr
 from sympy.printing.pycode import SymPyPrinter
 

--- a/ramanujantools/flint_core/numeric_matrix.py
+++ b/ramanujantools/flint_core/numeric_matrix.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Callable, Dict, List
+
+from flint import fmpq_mat, fmpq
+from sympy.utilities.lambdify import lambdastr
+from sympy.printing.pycode import SymPyPrinter
+
+import ramanujantools as rt
+from ramanujantools import Position
+
+
+class NumericMatrix(fmpq_mat):
+    @staticmethod
+    def eye(N: int):
+        """
+        Returns an identity matrix of size N
+        """
+        retval = NumericMatrix(N, N)
+        for i in range(N):
+            retval[i, i] = 1
+        return retval
+
+    @staticmethod
+    def lambda_from_rt(matrix: rt.Matrix) -> Callable:
+        """
+        Returns a function that evaluates the matrix at given a point
+        and returns it as a NumericMatrix.
+        """
+        # Makes sp.Rational(1, 2) print as "S(1)/2" rather than "1/2""
+        SymPyPrinter()._default_settings["sympy_integers"] = True
+
+        symbols = list(sorted(matrix.free_symbols, key=str))
+        evaluation_string = (
+            lambdastr(symbols, matrix, printer=SymPyPrinter)
+            .replace("ImmutableDenseMatrix", "NumericMatrix")
+            .replace("**S", "**")
+            .replace("S", "fmpq")
+        )
+
+        def fast_subs(substitutions: Dict):
+            values = [substitutions[symbol] for symbol in symbols]
+            return eval(evaluation_string)(*values)
+
+        return fast_subs
+
+    @staticmethod
+    def walk(
+        matrix: rt.Matrix, trajectory: Position, iterations: int, start: Position
+    ) -> NumericMatrix:
+        return NumericMatrix.walk_list(matrix, trajectory, [iterations], start)[0]
+
+    @staticmethod
+    def walk_list(
+        matrix: rt.Matrix, trajectory: Position, iterations: List[int], start: Position
+    ) -> List[NumericMatrix]:
+        results = []
+        position = start.copy()
+        fast_subs = NumericMatrix.lambda_from_rt(matrix)
+        retval = NumericMatrix.eye(matrix.rows)
+        for depth in range(0, iterations[-1]):
+            if depth in iterations:
+                results.append(NumericMatrix(retval))
+            retval *= fast_subs(position)
+            position += trajectory
+        results.append(NumericMatrix(retval))  # Last matrix, for iterations[-1]
+        return results
+
+    def to_rt(self) -> rt.Matrix:
+        return rt.Matrix(self.nrows(), self.ncols(), list(self))

--- a/ramanujantools/flint_core/numeric_matrix.py
+++ b/ramanujantools/flint_core/numeric_matrix.py
@@ -60,11 +60,35 @@ class NumericMatrix(fmpq_mat):
         retval = NumericMatrix.eye(matrix.rows)
         for depth in range(0, iterations[-1]):
             if depth in iterations:
-                results.append(NumericMatrix(retval))
+                results.append(retval)
             retval *= fast_subs(position)
             position += trajectory
-        results.append(NumericMatrix(retval))  # Last matrix, for iterations[-1]
+        results.append(retval)  # Last matrix, for iterations[-1]
         return results
 
     def to_rt(self) -> rt.Matrix:
         return rt.Matrix(self.nrows(), self.ncols(), list(self))
+
+    def __neg__(self) -> NumericMatrix:
+        return NumericMatrix(super().__neg__())
+
+    def __add__(self, other) -> NumericMatrix:
+        return NumericMatrix(super().__add__(other))
+
+    def __radd__(self, other) -> NumericMatrix:
+        return NumericMatrix(super().__radd__(other))
+
+    def __sub__(self, other) -> NumericMatrix:
+        return NumericMatrix(super().__sub__(other))
+
+    def __rsub__(self, other) -> NumericMatrix:
+        return NumericMatrix(super().__rsub__(other))
+
+    def __mul__(self, other) -> NumericMatrix:
+        return NumericMatrix(super().__mul__(other))
+
+    def __rmul__(self, other) -> NumericMatrix:
+        return NumericMatrix(super().__rmul__(other))
+
+    def __div__(self, other) -> NumericMatrix:
+        return NumericMatrix(super().__div__(other))

--- a/ramanujantools/flint_core/symbolic_matrix.py
+++ b/ramanujantools/flint_core/symbolic_matrix.py
@@ -11,7 +11,7 @@ from ramanujantools import Position
 from ramanujantools.flint_core import FlintRational, FlintContext
 
 
-class FlintMatrix:
+class SymbolicMatrix:
     """
     Represents a Matrix of FlintRationals.
 
@@ -20,25 +20,25 @@ class FlintMatrix:
 
     def __init__(
         self, rows: int, cols: int, values: List[FlintRational], ctx: FlintContext
-    ) -> FlintMatrix:
+    ) -> SymbolicMatrix:
         self._rows = rows
         self._cols = cols
         self.values = values
         self.ctx = ctx
 
     @staticmethod
-    def from_sympy(matrix: rt.Matrix, ctx: FlintContext) -> FlintMatrix:
+    def from_sympy(matrix: rt.Matrix, ctx: FlintContext) -> SymbolicMatrix:
         """
-        Converts a Matrix to FlintMatrix.
+        Converts a Matrix to SymbolicMatrix.
         Args:
             matrix: The matrix as ramanujantools.Matrix
             ctx: The desired mpoly context (which also defines the supported variables)
         """
         values = [FlintRational.from_sympy(cell, ctx) for cell in matrix]
-        return FlintMatrix(matrix.rows, matrix.cols, values, ctx)
+        return SymbolicMatrix(matrix.rows, matrix.cols, values, ctx)
 
     @staticmethod
-    def eye(N: int, ctx: FlintContext) -> FlintMatrix:
+    def eye(N: int, ctx: FlintContext) -> SymbolicMatrix:
         """
         Creates an identity matrix of size N.
 
@@ -51,7 +51,7 @@ class FlintMatrix:
         while current < N**2:
             values[current] += 1
             current += N + 1
-        return FlintMatrix(N, N, values, ctx)
+        return SymbolicMatrix(N, N, values, ctx)
 
     def __getitem__(self, key):
         """
@@ -108,16 +108,16 @@ class FlintMatrix:
         return data
 
     def __repr__(self) -> str:
-        return f"FlintMatrix({self.data()})"
+        return f"SymbolicMatrix({self.data()})"
 
     def __str__(self) -> str:
-        return f"FlintMatrix({self.data()})"
+        return f"SymbolicMatrix({self.data()})"
 
-    def __mul__(self, other: FlintMatrix | int) -> FlintMatrix:
+    def __mul__(self, other: SymbolicMatrix | int) -> SymbolicMatrix:
         """
-        Multiplies self by another FlintMatrix or a scalar.
+        Multiplies self by another SymbolicMatrix or a scalar.
         """
-        if isinstance(other, FlintMatrix):
+        if isinstance(other, SymbolicMatrix):
             if self.cols() != other.rows():
                 raise ValueError("Attempting to multiply")
             elements = []
@@ -127,42 +127,42 @@ class FlintMatrix:
                     for k in range(self.cols()):
                         current += self[row, k] * other[k, col]
                     elements.append(current)
-            return FlintMatrix(self.rows(), self.cols(), elements, self.ctx)
+            return SymbolicMatrix(self.rows(), self.cols(), elements, self.ctx)
 
         else:
-            return FlintMatrix(
+            return SymbolicMatrix(
                 self.rows(),
                 self.cols(),
                 [value * other for value in self.values],
                 self.ctx,
             )
 
-    def __rmul__(self, other: FlintMatrix | int) -> FlintMatrix:
+    def __rmul__(self, other: SymbolicMatrix | int) -> SymbolicMatrix:
         """
-        Multiplies a FlintMatrix or a scalar by self.
+        Multiplies a SymbolicMatrix or a scalar by self.
         """
         if isinstance(other, int):
             return self * other
         return other * self
 
-    def __truediv__(self, other: int) -> FlintMatrix:
+    def __truediv__(self, other: int) -> SymbolicMatrix:
         """
         Divides self by a scalar
         """
-        if isinstance(other, FlintMatrix):
+        if isinstance(other, SymbolicMatrix):
             raise ValueError("Attempted to divide by matrix!")
-        return FlintMatrix(
+        return SymbolicMatrix(
             self.rows(),
             self.cols(),
             [value / other for value in self.values],
             self.ctx,
         )
 
-    def subs(self, substitutions: Dict) -> FlintMatrix:
+    def subs(self, substitutions: Dict) -> SymbolicMatrix:
         """
         Substitutes symbols in the matrix.
         """
-        return FlintMatrix(
+        return SymbolicMatrix(
             self.rows(),
             self.cols(),
             [value.subs(substitutions) for value in self.values],
@@ -177,7 +177,7 @@ class FlintMatrix:
         return rt.Matrix(self.rows(), self.cols(), values)
 
     @multimethod
-    def walk(self, trajectory: Dict, iterations: List[int], start: Dict) -> FlintMatrix:
+    def walk(self, trajectory: Dict, iterations: List[int], start: Dict) -> SymbolicMatrix:
         r"""
         Returns the multiplication result of walking in a certain trajectory.
 
@@ -202,7 +202,7 @@ class FlintMatrix:
         position = Position(start)
         trajectory = Position(trajectory)
         results = []
-        matrix = FlintMatrix.eye(self.rows(), self.ctx)
+        matrix = SymbolicMatrix.eye(self.rows(), self.ctx)
         for depth in range(0, iterations[-1]):
             if depth in iterations:
                 results.append(matrix)

--- a/ramanujantools/flint_core/symbolic_matrix_test.py
+++ b/ramanujantools/flint_core/symbolic_matrix_test.py
@@ -2,12 +2,12 @@ import sympy as sp
 from sympy.abc import n
 
 from ramanujantools import Matrix
-from ramanujantools.flint_core import mpoly_ctx, FlintMatrix
+from ramanujantools.flint_core import mpoly_ctx, SymbolicMatrix
 
 
-def flintify(matrix: Matrix, fmpz=True) -> FlintMatrix:
+def flintify(matrix: Matrix, fmpz=True) -> SymbolicMatrix:
     ctx = mpoly_ctx(matrix.free_symbols, fmpz)
-    return FlintMatrix.from_sympy(matrix, ctx)
+    return SymbolicMatrix.from_sympy(matrix, ctx)
 
 
 def test_factor():

--- a/ramanujantools/matrix.py
+++ b/ramanujantools/matrix.py
@@ -10,11 +10,9 @@ import numpy as np
 import mpmath as mp
 import sympy as sp
 from sympy.abc import n
-from sympy.utilities.lambdify import lambdastr
-from sympy.printing.pycode import SymPyPrinter
 
 from ramanujantools import Position
-from ramanujantools.flint_core import mpoly_ctx, FlintMatrix
+from ramanujantools.flint_core import mpoly_ctx, FlintMatrix, NumericMatrix
 
 
 class Matrix(sp.Matrix):
@@ -84,35 +82,6 @@ class Matrix(sp.Matrix):
         subbed_out = set(trajectory.keys()).union(set(start.keys()))
 
         return (self.free_symbols - subbed_out).union(subbed_in) == set()
-
-    @lru_cache
-    def create_fast_subs(self) -> Callable:
-        """
-        Returns a function that evaluates the matrix at given substitutions.
-
-        Works by storing the matrix as a string, setting all local symbols as variables in the local scope,
-        and then simply (but not symply) returning it.
-        Evaluation occures in the python interpreter, rather by recursively substituting the sympy expressions.
-        This optimizes by a factor of 2~
-        """
-        # Makes sp.Rational(1, 2) print as "S(1)/2" rather than "1/2""
-        SymPyPrinter()._default_settings["sympy_integers"] = True
-
-        symbols = list(sorted(self.free_symbols, key=str))
-        evaluation_string = (
-            lambdastr(symbols, self, printer=SymPyPrinter)
-            .replace("ImmutableDenseMatrix", "fmpq_mat")
-            .replace("**S", "**")
-            .replace("S", "fmpq")
-        )
-
-        def fast_subs(substitutions: Dict):
-            values = [substitutions[symbol] for symbol in symbols]
-            print(evaluation_string)
-            print(values)
-            return eval(evaluation_string)(*values)
-
-        return fast_subs
 
     def is_square(self) -> int:
         """
@@ -295,21 +264,9 @@ class Matrix(sp.Matrix):
         Internal walk function, used for type conversions and for caching. Do not use directly.
         """
         if self._is_numeric_walk(trajectory, start):
-            results = []
-            position = start.copy()
-            fast_subs = self.create_fast_subs()
-            # Ugly way to construct an eye matrix of type fmpq_mat
-            matrix = Matrix.eye(self.rows).create_fast_subs()(position)
-            for depth in range(0, iterations[-1]):
-                if depth in iterations:
-                    results.append(matrix)
-                matrix *= fast_subs(position)
-                position += trajectory
-            results.append(matrix)  # Last matrix, for iterations[-1]
-            return [Matrix(self.rows, self.cols, list(result)) for result in results]
+            results = NumericMatrix.walk_list(self, trajectory, iterations, start)
+            return [result.to_rt() for result in results]
         else:
-            from ramanujantools.flint_core import FlintMatrix
-
             symbols = self.walk_free_symbols(start)
             as_flint = FlintMatrix.from_sympy(
                 self, mpoly_ctx(symbols, fmpz=start.is_polynomial())

--- a/ramanujantools/matrix.py
+++ b/ramanujantools/matrix.py
@@ -12,7 +12,7 @@ import sympy as sp
 from sympy.abc import n
 
 from ramanujantools import Position
-from ramanujantools.flint_core import mpoly_ctx, FlintMatrix, NumericMatrix
+from ramanujantools.flint_core import mpoly_ctx, SymbolicMatrix, NumericMatrix
 
 
 class Matrix(sp.Matrix):
@@ -145,7 +145,7 @@ class Matrix(sp.Matrix):
         return Matrix(sp.simplify(self))
 
     def factor(self) -> Matrix:
-        return FlintMatrix.from_sympy(
+        return SymbolicMatrix.from_sympy(
             self, mpoly_ctx(self.free_symbols, fmpz=True)
         ).factor()
 
@@ -268,7 +268,7 @@ class Matrix(sp.Matrix):
             return [result.to_rt() for result in results]
         else:
             symbols = self.walk_free_symbols(start)
-            as_flint = FlintMatrix.from_sympy(
+            as_flint = SymbolicMatrix.from_sympy(
                 self, mpoly_ctx(symbols, fmpz=start.is_polynomial())
             )
             results = as_flint.walk(trajectory, list(iterations), start)


### PR DESCRIPTION
Add the NumericMatrix class which wraps the flint.fmpq_mat type.
Renamed the FlintMatrix class to SymbolicMatrix.