### PR TITLE
Feature/ascension

### DIFF
--- a/ramanujantools/cmf/cmf.py
+++ b/ramanujantools/cmf/cmf.py
@@ -112,17 +112,6 @@ class CMF:
                     f"M({symbol}) is of dimension {matrix.rows}x{matrix.cols}, expected {expected_N}x{expected_N}"
                 )
 
-    @staticmethod
-    def walk_symbol() -> sp.Symbol:
-        return sp.Symbol("walk")
-
-    def ctx(self, start: Position | None) -> FlintContext:
-        start = Position(start) if start else Position()
-        free_symbols = (
-            self.free_symbols().union({CMF.walk_symbol()}).union(start.free_symbols())
-        )
-        return mpoly_ctx(free_symbols, fmpz=start.is_polynomial())
-
     def M(self, axis: sp.Symbol, sign: bool = True) -> Matrix:
         """
         Returns the axis matrix for a given axis.
@@ -134,6 +123,15 @@ class CMF:
             return self.matrices[axis]
         else:
             return self.matrices[axis].inverse()({axis: axis - 1})
+
+    def dual(self) -> CMF:
+        """
+        Returns the dual CMF which is defined with inverse-transpose matrices.
+        """
+        return CMF(
+            {axis: self.M(axis).inverse().transpose() for axis in self.axes()},
+            validate=False,
+        )
 
     def axes(self) -> set[sp.Symbol]:
         """
@@ -190,6 +188,17 @@ class CMF:
                 symbol: simplify(matrix) for symbol, matrix in self.matrices.items()
             }
         )
+
+    @staticmethod
+    def walk_symbol() -> sp.Symbol:
+        return sp.Symbol("walk")
+
+    def ctx(self, start: Position | None) -> FlintContext:
+        start = Position(start) if start else Position()
+        free_symbols = (
+            self.free_symbols().union({CMF.walk_symbol()}).union(start.free_symbols())
+        )
+        return mpoly_ctx(free_symbols, fmpz=start.is_polynomial())
 
     def _calculate_diagonal_matrix_backtrack(
         self, trajectory: Position, start: Position, ctx: FlintContext

--- a/ramanujantools/cmf/cmf.py
+++ b/ramanujantools/cmf/cmf.py
@@ -167,13 +167,33 @@ class CMF:
         random_matrix = list(self.matrices.values())[0]
         return random_matrix.rows
 
-    def subs(self, *args, **kwargs) -> CMF:
+    def _substitute_matrices(self, substitutions: Position) -> dict[sp.Symbol, Matrix]:
+        axes_substitutions = Position(
+            {key: value for key, value in substitutions.items() if key in self.axes()}
+        )
+        if not axes_substitutions.is_linear():
+            raise ValueError(
+                f"Axes can only be shifted linearly in the CMF, got: {axes_substitutions}"
+            )
+        return
+
+    def _validate_axes_substitutions(self, substitutions: Position) -> None:
+        if (
+            axes_substitutions := self.axes().intersection(substitutions.keys())
+            != set()
+        ):
+            raise ValueError(
+                f"Cannot substitute axis parameters! got: {axes_substitutions}"
+            )
+
+    def subs(self, substitutions: Position) -> CMF:
         """
         Returns a new CMF with substituted matrices.
         """
+        self._validate_axes_substitutions(substitutions)
         return CMF(
             matrices={
-                symbol: matrix.subs(*args, **kwargs)
+                symbol: matrix.subs(substitutions)
                 for symbol, matrix in self.matrices.items()
             },
             validate=False,

--- a/ramanujantools/cmf/cmf.py
+++ b/ramanujantools/cmf/cmf.py
@@ -167,16 +167,6 @@ class CMF:
         random_matrix = list(self.matrices.values())[0]
         return random_matrix.rows
 
-    def _substitute_matrices(self, substitutions: Position) -> dict[sp.Symbol, Matrix]:
-        axes_substitutions = Position(
-            {key: value for key, value in substitutions.items() if key in self.axes()}
-        )
-        if not axes_substitutions.is_linear():
-            raise ValueError(
-                f"Axes can only be shifted linearly in the CMF, got: {axes_substitutions}"
-            )
-        return
-
     def _validate_axes_substitutions(self, substitutions: Position) -> None:
         if (
             axes_substitutions := self.axes().intersection(substitutions.keys())

--- a/ramanujantools/cmf/cmf_test.py
+++ b/ramanujantools/cmf/cmf_test.py
@@ -7,6 +7,27 @@ from ramanujantools import Position, Matrix, simplify
 from ramanujantools.cmf import CMF, known_cmfs
 
 
+def test_N():
+    cmf = known_cmfs.hypergeometric_derived_2F1()
+    assert 2 == cmf.N()
+
+
+def test_dim():
+    cmf = known_cmfs.hypergeometric_derived_2F1()
+    assert 3 == cmf.dim()
+
+
+def test_dual_conserving():
+    cmf = known_cmfs.cmf2()
+    dual_cmf = cmf.dual()
+    dual_cmf.assert_conserving
+
+
+def test_dual_inverible():
+    cmf = known_cmfs.cmf1()
+    assert cmf == cmf.dual().dual()
+
+
 def test_assert_conserving():
     m = Matrix([[x, x + 17], [y * x, y * 3 - x + 5]])
     cmf = CMF(matrices={x: m, y: m}, validate=False)
@@ -174,16 +195,6 @@ def test_trajectory_substitution_diagonal():
     trajectory = {x: 1, y: 2}
     start = {x: 3, y: 5}
     assert {x: n + 2, y: 2 * n + 3} == cmf.trajectory_substitution(trajectory, start, n)
-
-
-def test_N():
-    cmf = known_cmfs.hypergeometric_derived_2F1()
-    assert 2 == cmf.N()
-
-
-def test_dim():
-    cmf = known_cmfs.hypergeometric_derived_2F1()
-    assert 3 == cmf.dim()
 
 
 def test_trajectory_matrix_walk_equivalence():

--- a/ramanujantools/cmf/cmf_test.py
+++ b/ramanujantools/cmf/cmf_test.py
@@ -46,6 +46,28 @@ def test_symbols():
     assert set().union(expected_axes, expected_parameters) == cmf.free_symbols()
 
 
+def test_subs():
+    cmf = known_cmfs.var_root_cmf()
+    substitution = Position({known_cmfs.c0: 1, known_cmfs.c1: 2 * known_cmfs.c1 - 3})
+    assert cmf.subs(substitution) == CMF(
+        {axis: matrix.subs(substitution) for axis, matrix in cmf.matrices.items()}
+    )
+
+
+def test_subs_axes_throw():
+    cmf = known_cmfs.e()
+    substitution = Position({x: 2})
+    with raises(ValueError):
+        cmf.subs(substitution)
+
+
+def test_subs_non_linear_shift_throws():
+    cmf = known_cmfs.e()
+    substitution = Position({x: x**2})
+    with raises(ValueError):
+        cmf.subs(substitution)
+
+
 def test_trajectory_matrix_axis():
     cmf = known_cmfs.e()
     assert cmf.trajectory_matrix({x: 3, y: 0}, {x: x, y: y}).walk(

--- a/ramanujantools/cmf/ffbar/ffbar.py
+++ b/ramanujantools/cmf/ffbar/ffbar.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import sympy as sp
 from sympy.abc import x, y
 
-from ramanujantools import Matrix
+from ramanujantools import Matrix, Position
 from ramanujantools.cmf import CMF
 
 
@@ -79,6 +81,10 @@ class FFbar(CMF):
 
     def __repr__(self):
         return f"FFbar({self.f}, {self.fbar})"
+
+    def subs(self, substitutions: Position) -> FFbar:
+        self._validate_axes_substitutions(substitutions)
+        return FFbar(self.f.subs(substitutions), self.fbar.subs(substitutions))
 
     @staticmethod
     def A(f, fbar) -> sp.Expr:

--- a/ramanujantools/cmf/ffbar/ffbar_test.py
+++ b/ramanujantools/cmf/ffbar/ffbar_test.py
@@ -1,6 +1,6 @@
 from sympy.abc import x, y
 
-from ramanujantools import Matrix
+from ramanujantools import Matrix, Position
 from ramanujantools.cmf import CMF, known_cmfs
 from ramanujantools.cmf.known_cmfs import c0, c1, c2, c3
 from ramanujantools.cmf.ffbar import FFbar
@@ -16,8 +16,15 @@ def test_quadratic_condition():
     assert FFbar.quadratic_condition(x**2 + x * y + y**2, x - y + 1) != 0
 
 
+def test_subs():
+    substitutions = Position({c0: c0**2, c1: 3 - c1, c2: 0})
+    cmf = known_cmfs.cmf1()
+    assert FFbar(cmf.f.subs(substitutions), cmf.fbar.subs(substitutions)) == cmf.subs(
+        substitutions
+    )
+
+
 def test_ffbar_construction():
-    c0, c1, c2,
     assert known_cmfs.cmf1() == CMF(
         matrices={
             x: Matrix(

--- a/ramanujantools/cmf/known_cmfs/pfq.py
+++ b/ramanujantools/cmf/known_cmfs/pfq.py
@@ -131,7 +131,7 @@ class pFq(CMF):
         3. The trajectory is padded with two zeros
         such that for any two choices of parameters $x_p, y_p$ such that $x_p - y_p \in \mathbb{Z}$,
         the ascended trajectory matrix contains all constants of the original,
-        and the ascended delta is the same as the original.
+        and the ascended delta is the same as the original (in a type-2 limit context).
         """
         ascended_cmf = pFq(
             self.p + 1,

--- a/ramanujantools/cmf/known_cmfs/pfq_test.py
+++ b/ramanujantools/cmf/known_cmfs/pfq_test.py
@@ -3,7 +3,29 @@ from sympy.abc import z
 
 from ramanujantools.cmf import CMF
 from ramanujantools.cmf.known_cmfs import pFq
-from ramanujantools import Matrix, IntegerRelation
+from ramanujantools import Matrix, IntegerRelation, Position
+
+x0, x1, x2 = sp.symbols("x:3")
+y0, y1 = sp.symbols("y:2")
+
+
+def test_subs():
+    cmf = pFq(2, 1)
+    assert pFq(2, 1, -1) == cmf.subs({z: -1})
+
+
+def test_ascend():
+    cmf = pFq(2, 1)
+    start = Position({x0: 1, x1: 2, y0: 3})
+    trajectory = Position({x0: 4, x1: 5, y0: 6})
+
+    expected_cmf = pFq(3, 2)
+    expected_start = start + Position({x2: x2, y1: y1})
+    expected_trajectory = trajectory + Position({x2: 0, y1: 0})
+
+    assert (expected_cmf, expected_trajectory, expected_start) == cmf.ascend(
+        trajectory, start
+    )
 
 
 def test_2F1_theta_derivative():

--- a/ramanujantools/cmf/known_cmfs/pfq_test.py
+++ b/ramanujantools/cmf/known_cmfs/pfq_test.py
@@ -1,12 +1,12 @@
 import sympy as sp
-from sympy.abc import z
+from sympy.abc import n, z
 
 from ramanujantools.cmf import CMF
 from ramanujantools.cmf.known_cmfs import pFq
 from ramanujantools import Matrix, IntegerRelation, Position
 
-x0, x1, x2 = sp.symbols("x:3")
-y0, y1 = sp.symbols("y:2")
+x0, x1, x2, x3 = sp.symbols("x:4")
+y0, y1, y2 = sp.symbols("y:3")
 
 
 def test_subs():
@@ -14,7 +14,7 @@ def test_subs():
     assert pFq(2, 1, -1) == cmf.subs({z: -1})
 
 
-def test_ascend():
+def test_ascend_symbolic():
     cmf = pFq(2, 1)
     start = Position({x0: 1, x1: 2, y0: 3})
     trajectory = Position({x0: 4, x1: 5, y0: 6})
@@ -26,6 +26,27 @@ def test_ascend():
     assert (expected_cmf, expected_trajectory, expected_start) == cmf.ascend(
         trajectory, start
     )
+
+
+def test_ascend_zeta2():
+    cmf = pFq(3, 2, 1)
+    trajectory = Position({x0: 1, x1: 1, x2: 1, y0: 2, y1: 2})
+    start = 3 * Position({x0: 1, x1: 1, x2: 1, y0: 2, y1: 2})
+
+    limit = cmf.trajectory_matrix(trajectory, start).limit({n: 1}, 200, {n: 1})
+    assert limit.identify(limit.mp.zeta(2)) is not None
+    delta = limit.delta(limit.mp.zeta(2))
+
+    a_cmf, a_trajectory, a_start = cmf.ascend(trajectory, start)
+    a_limit = (
+        a_cmf.trajectory_matrix(a_trajectory, a_start)
+        .subs({x3: 3, y2: 3})
+        .limit({n: 1}, 200, {n: 1})
+    )
+    assert a_limit.identify(a_limit.mp.zeta(2), maxcoeff=10**6) is not None
+    a_delta = a_limit.delta(a_limit.mp.zeta(2))
+
+    assert abs(delta - a_delta) < 0.01
 
 
 def test_2F1_theta_derivative():

--- a/ramanujantools/matrix.py
+++ b/ramanujantools/matrix.py
@@ -64,7 +64,7 @@ class Matrix(sp.Matrix):
         """
         return self.subs(substitutions)
 
-    def subs(self, substitutions: dict) -> Matrix:
+    def subs(self, substitutions: Position) -> Matrix:
         """
         Substitutes symbols in the matrix.
 

--- a/ramanujantools/position.py
+++ b/ramanujantools/position.py
@@ -109,8 +109,11 @@ class Position(dict[sp.Symbol, sp.Expr]):
     def free_symbols(self) -> set:
         symbols = set()
         for value in self.values():
-            symbols = symbols.union((sp.simplify(0) + value).free_symbols)
+            symbols = symbols.union((sp.S(0) + value).free_symbols)
         return symbols
+
+    def sorted(self) -> Position:
+        return Position({key: self[key] for key in sorted(self.keys(), key=str)})
 
     @staticmethod
     def from_list(values: list[sp.Expr], symbol: str) -> Position:


### PR DESCRIPTION
The first part towards an automatic search of type-2 limits for better deltas.
1. Added the CMF.dual method which returns an inverse-transpose CMF
2. Implemented the pFq.ascend algorithm
3. (bonus) Fixed the CMF.subs such that you cannot substitute axes and the pFq remembers your new z when substituting it.