### PR TITLE
bugfix/sympy-flint-conversions

### DIFF
--- a/ramanujantools/cmf/cmf.py
+++ b/ramanujantools/cmf/cmf.py
@@ -12,7 +12,7 @@ from ramanujantools.flint_core import (
     NumericMatrix,
     SymbolicMatrix,
     FlintContext,
-    mpoly_ctx,
+    flint_ctx,
 )
 
 
@@ -208,7 +208,7 @@ class CMF:
         free_symbols = (
             self.free_symbols().union({CMF.walk_symbol()}).union(start.free_symbols())
         )
-        return mpoly_ctx(free_symbols, fmpz=start.is_polynomial())
+        return flint_ctx(free_symbols, fmpz=start.is_polynomial())
 
     def _calculate_diagonal_matrix_backtrack(
         self, trajectory: Position, start: Position, ctx: FlintContext

--- a/ramanujantools/flint_core/__init__.py
+++ b/ramanujantools/flint_core/__init__.py
@@ -1,10 +1,18 @@
-from .context import mpoly_ctx, FlintPoly, FlintContext
+from .context import (
+    flint_ctx,
+    flint_from_sympy,
+    flint_to_sympy,
+    FlintPoly,
+    FlintContext,
+)
 from .rational import FlintRational
 from .symbolic_matrix import SymbolicMatrix
 from .numeric_matrix import NumericMatrix
 
 __all__ = [
-    "mpoly_ctx",
+    "flint_ctx",
+    "flint_from_sympy",
+    "flint_to_sympy",
     "FlintPoly",
     "FlintRational",
     "FlintContext",

--- a/ramanujantools/flint_core/context.py
+++ b/ramanujantools/flint_core/context.py
@@ -2,10 +2,10 @@ import flint
 import sympy as sp
 
 FlintContext = flint.fmpz_mpoly_ctx | flint.fmpq_mpoly_ctx
-FlintPoly = flint.fmpz_mpoly | flint.fmpq_mpoly_ctx
+FlintPoly = flint.fmpz_mpoly | flint.fmpq_mpoly
 
 
-def mpoly_ctx(symbols: list[sp.Symbol], fmpz: bool) -> FlintContext:
+def flint_ctx(symbols: list[sp.Symbol], fmpz: bool) -> FlintContext:
     """
     Creates a FlintContext
     Args:
@@ -16,3 +16,42 @@ def mpoly_ctx(symbols: list[sp.Symbol], fmpz: bool) -> FlintContext:
     return ctx_type.get(
         [str(symbol) for symbol in list(sorted(symbols, key=str))], "lex"
     )
+
+
+def flint_from_sympy(poly: sp.Expr, ctx: FlintContext) -> FlintPoly:
+    """
+    Converts a sympy expression to a flint mpoly.
+    """
+    gens = tuple(sp.Symbol(str(gen)) for gen in ctx.gens())
+    sp_poly = sp.Poly(poly, gens)
+    monoms = sp_poly.monoms()
+    coeffs = sp_poly.coeffs()
+    mpoly_type = type(ctx.constant(0))
+    # Detect if context is integer or rational
+    if "fmpz" in mpoly_type.__name__:
+        monom_dict = {monom: int(coeff) for monom, coeff in zip(monoms, coeffs)}
+    else:
+        monom_dict = {
+            monom: flint.fmpq(coeff.numerator, coeff.denominator)
+            for monom, coeff in zip(monoms, coeffs)
+        }
+    return mpoly_type(monom_dict, ctx)
+
+
+def flint_to_sympy(poly) -> sp.Expr:
+    """
+    Factors an mpoly polynomial and returns it as a sp.Expr
+    """
+    gens = poly.context().gens()
+    symbols = [sp.Symbol(str(gen)) for gen in gens]
+    content, factors = poly.factor()
+    p = sp.simplify(content)
+    for factor, multiplicity in factors:
+        coeffs = factor.coeffs()
+        monoms = factor.monoms()
+        expr = sum(
+            coeff * sp.Mul(*[sym**exp for sym, exp in zip(symbols, monom) if exp])
+            for coeff, monom in zip(coeffs, monoms)
+        )
+        p *= expr**multiplicity
+    return p

--- a/ramanujantools/flint_core/context.py
+++ b/ramanujantools/flint_core/context.py
@@ -49,7 +49,7 @@ def flint_to_sympy(poly) -> sp.Expr:
     p = sp.simplify(content)
     for factor, multiplicity in factors:
         expr = sum(
-            coeff * sp.Mul(*[sym**exp for sym, exp in zip(symbols, monom) if exp])
+            coeff * sp.Mul(*[sym**exp for sym, exp in zip(symbols, monom)])
             for monom, coeff in factor.terms()
         )
         p *= expr**multiplicity

--- a/ramanujantools/flint_core/rational_test.py
+++ b/ramanujantools/flint_core/rational_test.py
@@ -1,17 +1,17 @@
 import sympy as sp
 from sympy.abc import x, y
 
-from ramanujantools.flint_core import mpoly_ctx, FlintRational
+from ramanujantools.flint_core import flint_ctx, FlintRational
 
 
 def flintify(expr: sp.Expr, symbols: list = None, fmpz=True) -> FlintRational:
-    ctx = mpoly_ctx(symbols or list(expr.free_symbols), fmpz)
+    ctx = flint_ctx(symbols or list(expr.free_symbols), fmpz)
     return FlintRational.from_sympy(expr, ctx)
 
 
 def test_from_sympy():
     expression = (x + y - 3) / (x**2 - y)
-    ctx = mpoly_ctx(["x", "y"], fmpz=True)
+    ctx = flint_ctx(["x", "y"], fmpz=True)
     _x, _y = ctx.gens()
     expected = FlintRational(_x + _y - 3, _x**2 - _y, ctx)
     assert expected == flintify(expression)

--- a/ramanujantools/flint_core/symbolic_matrix_test.py
+++ b/ramanujantools/flint_core/symbolic_matrix_test.py
@@ -2,11 +2,11 @@ import sympy as sp
 from sympy.abc import n
 
 from ramanujantools import Matrix
-from ramanujantools.flint_core import mpoly_ctx, SymbolicMatrix
+from ramanujantools.flint_core import flint_ctx, SymbolicMatrix
 
 
 def flintify(matrix: Matrix, fmpz=True) -> SymbolicMatrix:
-    ctx = mpoly_ctx(matrix.free_symbols, fmpz)
+    ctx = flint_ctx(matrix.free_symbols, fmpz)
     return SymbolicMatrix.from_sympy(matrix, ctx)
 
 

--- a/ramanujantools/matrix.py
+++ b/ramanujantools/matrix.py
@@ -11,7 +11,7 @@ import sympy as sp
 from sympy.abc import n
 
 from ramanujantools import Position
-from ramanujantools.flint_core import mpoly_ctx, SymbolicMatrix, NumericMatrix
+from ramanujantools.flint_core import flint_ctx, SymbolicMatrix, NumericMatrix
 
 
 class Matrix(sp.Matrix):
@@ -145,7 +145,7 @@ class Matrix(sp.Matrix):
 
     def factor(self) -> Matrix:
         return SymbolicMatrix.from_sympy(
-            self, mpoly_ctx(self.free_symbols, fmpz=True)
+            self, flint_ctx(self.free_symbols, fmpz=True)
         ).factor()
 
     def singular_points(self) -> list[dict]:
@@ -170,7 +170,7 @@ class Matrix(sp.Matrix):
             The coboundary relation as described above
         """
         free_symbols = self.free_symbols.union({symbol})
-        ctx = mpoly_ctx(free_symbols, fmpz=True)
+        ctx = flint_ctx(free_symbols, fmpz=True)
         return (
             SymbolicMatrix.from_sympy(U.inverse(), ctx)
             * SymbolicMatrix.from_sympy(self, ctx)
@@ -184,7 +184,7 @@ class Matrix(sp.Matrix):
         if not (self.is_square()):
             raise ValueError("Only square matrices can have a coboundary relation")
         N = self.rows
-        ctx = mpoly_ctx(self.free_symbols, fmpz=True)
+        ctx = flint_ctx(self.free_symbols, fmpz=True)
         flint_self = SymbolicMatrix.from_sympy(self, ctx)
         vectors = [SymbolicMatrix.from_sympy(Matrix(N, 1, [1] + (N - 1) * [0]), ctx)]
         for _ in range(1, N):
@@ -253,7 +253,7 @@ class Matrix(sp.Matrix):
         else:
             symbols = self.walk_free_symbols(start)
             as_flint = SymbolicMatrix.from_sympy(
-                self, mpoly_ctx(symbols, fmpz=start.is_polynomial())
+                self, flint_ctx(symbols, fmpz=start.is_polynomial())
             )
             results = as_flint.walk(trajectory, list(iterations), start)
             return [result.factor() for result in results]


### PR DESCRIPTION
Fixed the conversion between flint and sympy that used `exec`, `eval` and `str(expr)`, which resulted in bad compatibility for windows users.