### PR TITLE
Bugfix/initial values everywhere

### DIFF
--- a/ramanujantools/cmf/cmf_test.py
+++ b/ramanujantools/cmf/cmf_test.py
@@ -102,12 +102,12 @@ def test_back_negates_forward():
 def test_trajectory_matrix_negative_axis():
     cmf = known_cmfs.e()
     start = {x: x, y: y}
-    assert cmf.trajectory_matrix({x: -3, y: 0}, start).limit_equivalent(
+    assert cmf.trajectory_matrix({x: -3, y: 0}, start).equal_projectively(
         cmf.M(x, False).walk(
             {x: -1, y: 0}, 3, cmf.trajectory_substitution({x: -3, y: 0}, start, n)
         )
     )
-    assert cmf.trajectory_matrix({x: 0, y: -2}, start).limit_equivalent(
+    assert cmf.trajectory_matrix({x: 0, y: -2}, start).equal_projectively(
         cmf.M(y, False).walk(
             {x: 0, y: -1}, 2, cmf.trajectory_substitution({x: 0, y: -2}, start, n)
         )
@@ -123,7 +123,7 @@ def test_trajectory_matrix_negative():
         * cmf.M(c, sign=False).subs({a: a + 1, b: b - 2})
     )
     actual = cmf.trajectory_matrix({a: 1, b: -2, c: -1}, {a: a, b: b, c: c})
-    assert actual.walk({n: 1}, 1, {n: 0}).limit_equivalent(expected)
+    assert actual.walk({n: 1}, 1, {n: 0}).equal_projectively(expected)
 
 
 def test_trajectory_matrix_rational():

--- a/ramanujantools/linear_recurrence.py
+++ b/ramanujantools/linear_recurrence.py
@@ -154,11 +154,15 @@ class LinearRecurrence:
         relation = [p * self.denominator_lcm / self.gcd for p in self.relation]
         return LinearRecurrence([sp.factor(p.simplify()) for p in relation])
 
-    def limit(self, iterations: int | list[int], start=1) -> Limit:
+    def limit(
+        self, iterations: int | list[int], start=0, initial_values: Matrix = None
+    ) -> Limit:
         r"""
         Returns the Limit matrix of the recursion up to a certain depth
         """
-        return self.recurrence_matrix.limit({n: 1}, iterations, {n: start})
+        return self.recurrence_matrix.limit(
+            {n: 1}, iterations, {n: start}, initial_values
+        )
 
     def fold(self, multiplier: sp.Expr) -> LinearRecurrence:
         r"""

--- a/ramanujantools/linear_recurrence_test.py
+++ b/ramanujantools/linear_recurrence_test.py
@@ -26,9 +26,12 @@ def test_matrix():
 
 
 def test_limit():
-    r = LinearRecurrence([1, n, n**2])
+    initial_values = Matrix([[2, 3, 5], [7, 11, 13]])
+    r = LinearRecurrence([1, n + 1, n**2])
     depths = [2, 3, 19, 101]
-    assert r.limit(depths) == r.recurrence_matrix.limit({n: 1}, depths, {n: 1})
+    assert r.limit(depths, 0, initial_values) == r.recurrence_matrix.limit(
+        {n: 1}, depths, {n: 0}, initial_values
+    )
 
 
 def test_inflate():

--- a/ramanujantools/matrix.py
+++ b/ramanujantools/matrix.py
@@ -334,13 +334,17 @@ class Matrix(sp.Matrix):
         trajectory: dict,
         iterations: list[int],
         start: dict,
+        initial_values: Matrix | None = None,
+        final_projection: Matrix | None = None,
     ) -> list[Matrix]:  # noqa: F811
         from ramanujantools import Limit
 
         def walk_function(iterations):
             return self.walk(trajectory, iterations, start)
 
-        return Limit.walk_to_limit(iterations, walk_function)
+        return Limit.walk_to_limit(
+            iterations, walk_function, initial_values, final_projection
+        )
 
     @multimethod
     def limit(  # noqa: F811
@@ -348,8 +352,12 @@ class Matrix(sp.Matrix):
         trajectory: dict,
         iterations: int,
         start: dict,
+        initial_values: Matrix | None = None,
+        final_projection: Matrix | None = None,
     ):
-        return self.limit(trajectory, [iterations], start)[0]
+        return self.limit(
+            trajectory, [iterations], start, initial_values, final_projection
+        )[0]
 
     def as_pcf(self, deflate_all=True):
         """

--- a/ramanujantools/matrix.py
+++ b/ramanujantools/matrix.py
@@ -118,10 +118,10 @@ class Matrix(sp.Matrix):
         # sp.gcd(t.simplify(), x) == 1
         return (self / self.gcd).simplify()
 
-    def limit_equivalent(self, other: Matrix) -> bool:
+    def equal_projectively(self, other: Matrix) -> bool:
         """
-        Returns true iff two matrices are limit equivalent.
-        Two matrices are limit equivalent iff self = c * other for some c.
+        Returns true iff two matrices are equal projectively.
+        Two matrices are equal projectively iff self = c * other for some c.
         """
         return self.as_polynomial().reduce() == other.as_polynomial().reduce()
 

--- a/ramanujantools/matrix_test.py
+++ b/ramanujantools/matrix_test.py
@@ -271,6 +271,17 @@ def test_limit_list():
         )
 
 
+def test_limit_initial_values():
+    trajectory = {x: 2, y: 3}
+    start = {x: 5, y: 7}
+    iterations = 10
+    m = Matrix([[x, 3 * x + 5 * y], [y**7 + x - 3, x**5]])
+    initial_values = Matrix([[2, 3, 5], [7, 11, 13]])
+    limit = m.limit(trajectory, iterations, start, initial_values)
+    assert initial_values == limit.initial_values
+    assert limit != m.limit(trajectory, iterations, start)
+
+
 def test_charpoly():
     m = Matrix([[0, -(n**2)], [1, (3 * n + 1)]])
     assert sp.Matrix(m).charpoly() == m.charpoly(poincare=False)


### PR DESCRIPTION
Fix the bug where `Matrix` and `LinearRecurrence` did not support receiving `initial_values` in their respective `limit` functions.