### PR TITLE
bugfix/identify-returns-zeros

### DIFF
--- a/ramanujantools/limit.py
+++ b/ramanujantools/limit.py
@@ -30,7 +30,9 @@ def most_round_in_range(num: mp.mpf, err: mp.mpf) -> str:
     return min(round_attempt(num, num + err), round_attempt(num - err, num), key=len)
 
 
-def coefficients_from_pslq(pslq_results: list[int], active_indices: list[int], N: int):
+def coefficients_from_pslq(
+    pslq_results: list[int], active_indices: list[int], N: int
+) -> list[int]:
     coefficients = [0] * N
     for i in active_indices:
         coefficients[i] = pslq_results.pop(0)
@@ -278,16 +280,16 @@ class Limit:
             return None
         # We normalize the sign so that the first coefficient is positive,
         # to avoid ambiguity as results are equivalent up to the sign.
-        numerator = Matrix(
-            coefficients_from_pslq(pslq_result[:total_indices], used_indices, self.N())
+        numerator_coeffs = coefficients_from_pslq(
+            pslq_result[:total_indices], used_indices, self.N()
         )
-        denominator = Matrix(
-            coefficients_from_pslq(pslq_result[total_indices:], used_indices, self.N())
+        numerator = Matrix([numerator_coeffs])
+        denominator_coeffs = coefficients_from_pslq(
+            pslq_result[total_indices:], used_indices, self.N()
         )
-        sign = sp.sign(numerator[0])
-        initial_values = Matrix.hstack(
-            sign * numerator, -sign * denominator
-        ).transpose()
+        denominator = Matrix([denominator_coeffs])
+        sign = sp.sign(numerator[0]) or 1
+        initial_values = Matrix.vstack(sign * numerator, -sign * denominator)
         self.initial_values = initial_values
         self.final_projection = Matrix.hstack(
             Matrix.e(self.N(), column_index),

--- a/ramanujantools/linear_recurrence_test.py
+++ b/ramanujantools/linear_recurrence_test.py
@@ -158,6 +158,27 @@ def test_gamma():
     assert PCF(-2 * (n + 2), -((n + 1) ** 2)) == pcf
 
 
+def test_euler_gompertz_independent():
+    # from https://arxiv.org/abs/0902.1768
+    r = LinearRecurrence(
+        [
+            (16 * n + 1) * (16 * n - 15),
+            (16 * n - 15) * (256 * n**3 + 528 * n**2 + 352 * n + 73),
+            -(16 * n + 17) * (128 * n**3 + 40 * n**2 - 82 * n - 45),
+            n**2 * (16 * n + 17) * (16 * n + 1),
+        ]
+    )
+
+    def gompertz(mp):
+        return -mp.e * mp.ei(-1)
+
+    def constant(mp):
+        return mp.e * mp.euler + gompertz(mp)
+
+    limit = r.limit(200, 1)
+    assert Matrix([[0, 0, 17], [-3, -2, 7]]) == limit.identify(constant(limit.mp))
+
+
 def test_apteshuffle():
     expected = LinearRecurrence(  # from the paper
         [


### PR DESCRIPTION
Fix the bug where a zero matrix was returned from the initial values due to sign=0