### PR TITLE
CMF pickling hotfix

### DIFF
--- a/ramanujantools/cmf/cmf.py
+++ b/ramanujantools/cmf/cmf.py
@@ -77,6 +77,7 @@ class CMF:
 
     def __setstate__(self, state):
         self.matrices = state
+        self._negative_matrices_cache = {}
 
     def _are_conserving(
         self,


### PR DESCRIPTION
Issue: unable to pickle CMF correctly as there was a missing attribute.
Fix: add the attribute to `__setstate__` with default value.