### PR TITLE
fix: LaTeX rendering in JupyterLab by subclassing Printable

### DIFF
--- a/ramanujantools/cmf/cmf.py
+++ b/ramanujantools/cmf/cmf.py
@@ -5,6 +5,7 @@ import itertools
 
 import sympy as sp
 from sympy.abc import n
+from sympy.printing.defaults import Printable
 
 from ramanujantools import Position, Matrix, Limit
 from ramanujantools.flint_core import (
@@ -17,7 +18,7 @@ from ramanujantools.flint_core import (
 from ramanujantools.utils import batched, Batchable
 
 
-class CMF:
+class CMF(Printable):
     r"""
     Represents a Conservative Matrix Field (CMF).
 
@@ -68,9 +69,6 @@ class CMF:
                 f"{printer.doprint(axis)} \\mapsto {printer.doprint(self.M(axis))}"
             )
         return r"\begin{array}{l}" + r"\\ ".join(lines) + r"\end{array}"
-
-    def _repr_latex_(self) -> str:
-        return rf"{sp.latex(self)}"
 
     def __getstate__(self):
         return self.matrices

--- a/ramanujantools/linear_recurrence.py
+++ b/ramanujantools/linear_recurrence.py
@@ -7,6 +7,7 @@ from tqdm import tqdm
 
 import sympy as sp
 from sympy.abc import n
+from sympy.printing.defaults import Printable
 
 from ramanujantools import Matrix, Limit, GenericPolynomial
 from ramanujantools.utils import batched, Batchable
@@ -19,7 +20,7 @@ def trim_trailing_zeros(sequence: list[int]) -> list[int]:
     return sequence[0:ending]
 
 
-class LinearRecurrence:
+class LinearRecurrence(Printable):
     r"""
     Represents a linear recurrence of the form
     $\sum_{i=0}^{N}a_i(n) p(n - i) = 0$
@@ -105,9 +106,6 @@ class LinearRecurrence:
 
     def _latex(self, printer) -> str:
         return f"{printer.doprint(self._symbolic_relation())} = 0"
-
-    def _repr_latex_(self) -> str:
-        return rf"{sp.latex(self)}"
 
     def _symbolic_relation(self) -> sp.Expr:
         terms = [

--- a/ramanujantools/pcf/pcf.py
+++ b/ramanujantools/pcf/pcf.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import mpmath as mp
 import sympy as sp
 from sympy.abc import n
+from sympy.printing.defaults import Printable
 
 from ramanujantools import Matrix, Limit, LinearRecurrence
 from ramanujantools.utils import batched, Batchable
@@ -56,7 +57,7 @@ def content(a, b, variables):
     return sp.simplify(c_n)
 
 
-class PCF:
+class PCF(Printable):
     """
     Represents a Polynomial Continued Fraction (PCF).
     """
@@ -119,9 +120,6 @@ class PCF:
         a_0 = printer.doprint(self.a_n.subs({n: 0}))
         b_1 = printer.doprint(self.b_n.subs({n: 1}))
         return rf"{a_0} + \cfrac{{{b_1}}}{{{recurse(1, DEPTH)}}}"
-
-    def _repr_latex_(self) -> str:
-        return rf"{sp.latex(self)}"
 
     def degrees(self) -> tuple[int, int]:
         """


### PR DESCRIPTION
## Summary
- Fix broken LaTeX rendering in JupyterLab caused by missing math mode delimiters (`$...$`)
- Replace custom `_repr_latex_` methods with `sympy.printing.defaults.Printable` inheritance
- `Printable` automatically provides `_repr_latex_` using existing `_latex()` methods and wraps output in `$\displaystyle ...$`

## Test plan
- [ ] Open a Jupyter notebook and verify `PCF`, `CMF`, and `LinearRecurrence` objects render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)