### PR TITLE
bugfix/flint-rational-equality

### DIFF
--- a/ramanujantools/flint_core/rational.py
+++ b/ramanujantools/flint_core/rational.py
@@ -105,9 +105,7 @@ class FlintRational:
         return f"FlintRational({self.numerator}, {self.denominator})"
 
     def __eq__(self, other: FlintRational) -> bool:
-        return (
-            self.numerator == other.numerator and self.denominator == other.denominator
-        )
+        return self.numerator * other.denominator == self.denominator * other.numerator
 
     def degrees(self) -> list[int]:
         return [max(poly.degrees()) for poly in [self.numerator, self.denominator]]

--- a/ramanujantools/flint_core/rational_test.py
+++ b/ramanujantools/flint_core/rational_test.py
@@ -60,6 +60,14 @@ def test_eq():
     assert expr == expr / 2 + 3 - 3 + expr / 2
 
 
+def test_eq_negation():
+    rational = flintify((x + 1) / (x - 1))
+    assert (
+        FlintRational(-rational.numerator, -rational.denominator, rational.ctx)
+        == rational
+    )
+
+
 def test_factor():
     expected = (x + y) * (x**2 + y**2) * (y - 3) / ((x + 17) * (y - 15) * (x * y + 1))
     assert expected == flintify(expected.expand()).factor()


### PR DESCRIPTION
Fix equality issue in FlintRational with negation in both numerator and denominator