### PR TITLE
bugfix/trajectory-matrix-excessive-backtracking

### DIFF
--- a/ramanujantools/cmf/cmf.py
+++ b/ramanujantools/cmf/cmf.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
-from functools import lru_cache
 
+import random
 import itertools
+from functools import lru_cache
 
 import sympy as sp
 from sympy.abc import n
@@ -294,27 +295,37 @@ class CMF(Printable):
     ) -> SymbolicMatrix:
         """
         Inner function of an inner function. DO NOT USE DIRECTLY.
-        This is the backtracking hook used for `_calculate_diagonal_marix`.
-        It's used to look for a non-singular path towards the trajectroy matrix.
+        This iterative approach replaces backtracking to find a non-singular path.
+        It evaluates permutations of the trajectory axes in random order to avoid
+        getting stuck in localized DFS failure branches.
         """
         if trajectory.longest() == 0:
             return SymbolicMatrix.eye(self.rank(), ctx)
-        for axis in sorted(trajectory.keys(), key=str):
+
+        axes = list(trajectory.keys())
+        rng = random.Random(42)
+        all_paths = list(itertools.permutations(axes))
+        rng.shuffle(all_paths)
+
+        for path in all_paths:
             try:
-                inner_trajectory = trajectory.copy()
                 position = start.copy()
-                sign = inner_trajectory[axis] >= 0
-                current = SymbolicMatrix.from_sympy(self.M(axis, sign), ctx).subs(
-                    position
-                )
-                position[axis] += inner_trajectory.pop(axis)
-                return current * self._calculate_diagonal_matrix_backtrack(
-                    inner_trajectory, position, ctx
-                )
+                result = SymbolicMatrix.eye(self.rank(), ctx)
+
+                for axis in path:
+                    sign = trajectory[axis] >= 0
+                    current = SymbolicMatrix.from_sympy(self.M(axis, sign), ctx).subs(
+                        position
+                    )
+                    position[axis] += trajectory[axis]
+                    result *= current
+                return result
+
             except ZeroDivisionError:
                 continue
+
         raise ZeroDivisionError(
-            "A singularity has occured in every possible trajectory combination"
+            "A singularity has occurred in every possible trajectory combination"
         )
 
     @lru_cache
@@ -351,23 +362,38 @@ class CMF(Printable):
         Internal work logic. Do not use directly.
         """
         ctx = self.ctx(start)
-        # Stopping condition: l-infinity norm of trajectory is less than 1
         if trajectory.longest() <= 1:
             return self._calculate_diagonal_matrix(trajectory, start, ctx)
 
         result = SymbolicMatrix.eye(self.rank(), ctx)
         symbol = CMF.walk_symbol()
-        depth = trajectory.shortest()
         position = start.copy()
-        while depth > 0:
-            diagonal = trajectory.signs()
-            result *= self._trajectory_matrix_inner(diagonal, position, symbol).walk(
-                {symbol: 1}, int(depth), {symbol: 0}
-            )
-            position += depth * diagonal
-            trajectory -= depth * diagonal
-            depth = trajectory.shortest()
-        return result
+        diagonals = trajectory.diagonal_decomposition()
+
+        rng = random.Random(42)
+        all_diagonals = list(itertools.permutations(diagonals))
+        rng.shuffle(all_diagonals)
+
+        rng = random.Random(42)
+        rng.shuffle(diagonals)
+
+        for diagonal_combination in all_diagonals:
+            try:
+                for multiplicity, diagonal in diagonal_combination:
+                    result *= self._trajectory_matrix_inner(
+                        diagonal, position, symbol
+                    ).walk({symbol: 1}, int(multiplicity), {symbol: 0})
+                    distance = multiplicity * diagonal
+                    position += distance
+                    trajectory -= distance
+                return result
+
+            except ZeroDivisionError:
+                continue
+
+        raise ZeroDivisionError(
+            "A singularity has occurred in every possible trajectory combination"
+        )
 
     def _work_numeric(
         self,
@@ -378,7 +404,6 @@ class CMF(Printable):
         Internal work logic. Do not use directly.
         """
         ctx = self.ctx(start)
-        # Stopping condition: l-infinity norm of trajectory is less than 1
         if trajectory.longest() <= 1:
             matrix = self._calculate_diagonal_matrix(trajectory, start, ctx).factor()
             return NumericMatrix.lambda_from_rt(matrix)(start)

--- a/ramanujantools/cmf/cmf.py
+++ b/ramanujantools/cmf/cmf.py
@@ -290,15 +290,29 @@ class CMF(Printable):
         )
         return flint_ctx(free_symbols, fmpz=start.is_polynomial())
 
-    def _calculate_diagonal_matrix_backtrack(
+    @lru_cache
+    def _calculate_diagonal_matrix(
         self, trajectory: Position, start: Position, ctx: FlintContext
     ) -> SymbolicMatrix:
         """
-        Inner function of an inner function. DO NOT USE DIRECTLY.
-        This iterative approach replaces backtracking to find a non-singular path.
-        It evaluates permutations of the trajectory axes in random order to avoid
-        getting stuck in localized DFS failure branches.
+        The manual calculation of trajectory matrix in the stopping condition.
+        You should probably use `trajectory_matrix` instead.
+
+        Assumes trajectory is a simple diagonal - all abs values are at most 1
+        Args:
+            trajectory: a dict containing the amount of steps in each direction.
+            start: a dict representing the starting point of the multiplication.
+        Returns:
+            A matrix that represents a single step in the desired trajectory
         """
+        if trajectory.longest() > 1:
+            raise ValueError(
+                f"Called _calculate_diagonal_matrix with a trajectory that is not a simple diagonal: {trajectory}"
+            )
+        trajectory = Position(
+            {axis: value for axis, value in trajectory.items() if value != 0}
+        )
+
         if trajectory.longest() == 0:
             return SymbolicMatrix.eye(self.rank(), ctx)
 
@@ -327,31 +341,6 @@ class CMF(Printable):
         raise ZeroDivisionError(
             "A singularity has occurred in every possible trajectory combination"
         )
-
-    @lru_cache
-    def _calculate_diagonal_matrix(
-        self, trajectory: Position, start: Position, ctx: FlintContext
-    ) -> SymbolicMatrix:
-        """
-        The manual calculation of trajectory matrix in the stopping condition.
-        You should probably use `trajectory_matrix` instead.
-
-        Assumes trajectory is a simple diagonal - all abs values are at most 1
-        Args:
-            trajectory: a dict containing the amount of steps in each direction.
-            start: a dict representing the starting point of the multiplication.
-        Returns:
-            A matrix that represents a single step in the desired trajectory
-        """
-        if trajectory.longest() > 1:
-            raise ValueError(
-                f"Called _calculate_diagonal_matrix with a trajectory that is not a simple diagonal: {trajectory}"
-            )
-        trajectory = Position(
-            {axis: value for axis, value in trajectory.items() if value != 0}
-        )
-
-        return self._calculate_diagonal_matrix_backtrack(trajectory, start, ctx)
 
     def _work_symbolic(
         self,

--- a/ramanujantools/cmf/cmf.py
+++ b/ramanujantools/cmf/cmf.py
@@ -319,12 +319,11 @@ class CMF(Printable):
         all_paths = list(itertools.permutations(axes))
 
         for axis_ordering in all_paths:
-            axis_ordering = list(reversed(axis_ordering))
             try:
                 position = start.copy()
                 result = SymbolicMatrix.eye(self.rank(), ctx)
 
-                for axis in axis_ordering:
+                for axis in reversed(axis_ordering):
                     sign = trajectory[axis] >= 0
                     current = SymbolicMatrix.from_sympy(self.M(axis, sign), ctx).subs(
                         position
@@ -357,12 +356,11 @@ class CMF(Printable):
 
         all_diagonals = itertools.permutations(diagonals)
         for diagonal_combination in all_diagonals:
-            diagonal_combination = list(reversed(diagonal_combination))
             try:
                 result = SymbolicMatrix.eye(self.rank(), ctx)
                 position = start.copy()
                 leftover_trajectory = trajectory.copy()
-                for multiplicity, diagonal in diagonal_combination:
+                for multiplicity, diagonal in reversed(diagonal_combination):
                     result *= self._trajectory_matrix_inner(
                         diagonal, position, symbol
                     ).walk({symbol: 1}, int(multiplicity), {symbol: 0})

--- a/ramanujantools/cmf/cmf.py
+++ b/ramanujantools/cmf/cmf.py
@@ -352,22 +352,23 @@ class CMF(Printable):
         if trajectory.longest() <= 1:
             return self._calculate_diagonal_matrix(trajectory, start, ctx)
 
-        result = SymbolicMatrix.eye(self.rank(), ctx)
         symbol = CMF.walk_symbol()
-        position = start.copy()
         diagonals = trajectory.diagonal_decomposition()
 
         all_diagonals = itertools.permutations(diagonals)
         for diagonal_combination in all_diagonals:
             diagonal_combination = list(reversed(diagonal_combination))
             try:
+                result = SymbolicMatrix.eye(self.rank(), ctx)
+                position = start.copy()
+                leftover_trajectory = trajectory.copy()
                 for multiplicity, diagonal in diagonal_combination:
                     result *= self._trajectory_matrix_inner(
                         diagonal, position, symbol
                     ).walk({symbol: 1}, int(multiplicity), {symbol: 0})
                     distance = multiplicity * diagonal
                     position += distance
-                    trajectory -= distance
+                    leftover_trajectory -= distance
                 return result
 
             except ZeroDivisionError:

--- a/ramanujantools/cmf/cmf.py
+++ b/ramanujantools/cmf/cmf.py
@@ -316,7 +316,7 @@ class CMF(Printable):
             return SymbolicMatrix.eye(self.rank(), ctx)
 
         axes = list(trajectory.keys())
-        all_paths = list(itertools.permutations(axes))
+        all_paths = itertools.permutations(axes)
 
         for axis_ordering in all_paths:
             try:
@@ -359,14 +359,12 @@ class CMF(Printable):
             try:
                 result = SymbolicMatrix.eye(self.rank(), ctx)
                 position = start.copy()
-                leftover_trajectory = trajectory.copy()
                 for multiplicity, diagonal in reversed(diagonal_combination):
                     result *= self._trajectory_matrix_inner(
                         diagonal, position, symbol
                     ).walk({symbol: 1}, multiplicity, {symbol: 0})
                     distance = multiplicity * diagonal
                     position += distance
-                    leftover_trajectory -= distance
                 return result
 
             except ZeroDivisionError:

--- a/ramanujantools/cmf/cmf.py
+++ b/ramanujantools/cmf/cmf.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import random
 import itertools
 from functools import lru_cache
 
@@ -317,16 +316,15 @@ class CMF(Printable):
             return SymbolicMatrix.eye(self.rank(), ctx)
 
         axes = list(trajectory.keys())
-        rng = random.Random(42)
         all_paths = list(itertools.permutations(axes))
-        rng.shuffle(all_paths)
 
-        for path in all_paths:
+        for axis_ordering in all_paths:
+            axis_ordering = list(reversed(axis_ordering))
             try:
                 position = start.copy()
                 result = SymbolicMatrix.eye(self.rank(), ctx)
 
-                for axis in path:
+                for axis in axis_ordering:
                     sign = trajectory[axis] >= 0
                     current = SymbolicMatrix.from_sympy(self.M(axis, sign), ctx).subs(
                         position
@@ -359,14 +357,9 @@ class CMF(Printable):
         position = start.copy()
         diagonals = trajectory.diagonal_decomposition()
 
-        rng = random.Random(42)
-        all_diagonals = list(itertools.permutations(diagonals))
-        rng.shuffle(all_diagonals)
-
-        rng = random.Random(42)
-        rng.shuffle(diagonals)
-
+        all_diagonals = itertools.permutations(diagonals)
         for diagonal_combination in all_diagonals:
+            diagonal_combination = list(reversed(diagonal_combination))
             try:
                 for multiplicity, diagonal in diagonal_combination:
                     result *= self._trajectory_matrix_inner(

--- a/ramanujantools/cmf/cmf.py
+++ b/ramanujantools/cmf/cmf.py
@@ -363,7 +363,7 @@ class CMF(Printable):
                 for multiplicity, diagonal in reversed(diagonal_combination):
                     result *= self._trajectory_matrix_inner(
                         diagonal, position, symbol
-                    ).walk({symbol: 1}, int(multiplicity), {symbol: 0})
+                    ).walk({symbol: 1}, multiplicity, {symbol: 0})
                     distance = multiplicity * diagonal
                     position += distance
                     leftover_trajectory -= distance

--- a/ramanujantools/cmf/cmf_benchmark.py
+++ b/ramanujantools/cmf/cmf_benchmark.py
@@ -1,5 +1,6 @@
 import sympy as sp
 
+from ramanujantools import Position
 from ramanujantools.cmf import CMF, e, pFq
 
 a0, a1 = sp.symbols("a:2")
@@ -8,40 +9,45 @@ x0, x1, x2, x3 = sp.symbols("x:4")
 y0, y1, y2, y3 = sp.symbols("y:4")
 
 
+def uncached_trajectory_matrix(cmf, trajectory, start):
+    cmf._calculate_diagonal_matrix.cache_clear()
+    return cmf.trajectory_matrix(trajectory, start)
+
+
 def test_trajectory_matrix_simple(benchmark):
     from sympy.abc import x, y
 
     cmf = e()
-    start = {x: 1, y: 1}
-    trajectory = {x: 1, y: 1}
-    benchmark(CMF.trajectory_matrix, cmf, trajectory, start)
+    start = Position({x: 1, y: 1})
+    trajectory = Position({x: 1, y: 1})
+    benchmark(uncached_trajectory_matrix, cmf, trajectory, start)
 
 
 def test_trajectory_matrix_2f2_euler(benchmark):
     x0, x1 = sp.symbols("x:2")
     y0, y1 = sp.symbols("y:2")
     cmf = pFq(2, 2, -1)
-    start = {x0: 1, x1: 1, y0: -1, y1: -1}
-    trajectory = {x0: 1, x1: 1, y0: 0, y1: -1}
-    benchmark(CMF.trajectory_matrix, cmf, trajectory, start)
+    start = Position({x0: 1, x1: 1, y0: -1, y1: -1})
+    trajectory = Position({x0: 1, x1: 1, y0: 0, y1: -1})
+    benchmark(uncached_trajectory_matrix, cmf, trajectory, start)
 
 
 def test_trajectory_matrix_2f2_deep(benchmark):
     x0, x1 = sp.symbols("x:2")
     y0, y1 = sp.symbols("y:2")
     cmf = pFq(2, 2, -1)
-    start = {x0: 1, x1: 1, y0: -1, y1: 1}
-    trajectory = {x0: 12, x1: 13, y0: -14, y1: 20}
-    benchmark(CMF.trajectory_matrix, cmf, trajectory, start)
+    start = Position({x0: 1, x1: 1, y0: -1, y1: 1})
+    trajectory = Position({x0: 12, x1: 13, y0: -14, y1: 20})
+    benchmark(uncached_trajectory_matrix, cmf, trajectory, start)
 
 
 def test_trajectory_matrix_3f2(benchmark):
     x0, x1, x2 = sp.symbols("x:3")
     y0, y1 = sp.symbols("y:2")
     cmf = pFq(3, 2, 1)
-    start = {x0: 2, x1: 2, x2: 2, y0: 4, y1: 4}
-    trajectory = {x0: 5, x1: 5, x2: 5, y0: 10, y1: 10}
-    benchmark(CMF.trajectory_matrix, cmf, trajectory, start)
+    start = Position({x0: 2, x1: 2, x2: 2, y0: 4, y1: 4})
+    trajectory = Position({x0: 5, x1: 5, x2: 5, y0: 10, y1: 10})
+    benchmark(uncached_trajectory_matrix, cmf, trajectory, start)
 
 
 def test_trajectory_matrix_3f2_rational(benchmark):
@@ -55,52 +61,59 @@ def test_trajectory_matrix_3f2_rational(benchmark):
         y0: sp.Rational(3, 2),
         y1: sp.Rational(3, 2),
     }
-    trajectory = {x0: 5, x1: 5, x2: 5, y0: 10, y1: 10}
-    benchmark(CMF.trajectory_matrix, cmf, trajectory, start)
+    trajectory = Position({x0: 5, x1: 5, x2: 5, y0: 10, y1: 10})
+    benchmark(uncached_trajectory_matrix, cmf, trajectory, start)
 
 
 def test_trajectory_matrix_3f2_pertubated(benchmark):
     x0, x1, x2 = sp.symbols("x:3")
     y0, y1 = sp.symbols("y:2")
     cmf = pFq(3, 2, 1)
-    start = {x0: 2, x1: 2, x2: 2, y0: 4, y1: 4}
-    trajectory = {x0: 5, x1: 6, x2: 5, y0: 10, y1: 11}
-    benchmark(CMF.trajectory_matrix, cmf, trajectory, start)
+    start = Position({x0: 2, x1: 2, x2: 2, y0: 4, y1: 4})
+    trajectory = Position({x0: 5, x1: 6, x2: 5, y0: 10, y1: 11})
+    benchmark(uncached_trajectory_matrix, cmf, trajectory, start)
 
 
 def test_trajectory_matrix_4f3(benchmark):
     x0, x1, x2, x3 = sp.symbols("x:4")
     y0, y1, y2 = sp.symbols("y:3")
     cmf = pFq(4, 3, 1)
-    start = {x0: 1, x1: 1, x2: 2, x3: 2, y0: 3, y1: 3, y2: 4}
-    trajectory = {x0: 1, x1: 1, x2: 2, x3: 2, y0: 3, y1: 3, y2: 4}
-    benchmark(CMF.trajectory_matrix, cmf, trajectory, start)
+    start = Position({x0: 1, x1: 1, x2: 2, x3: 2, y0: 3, y1: 3, y2: 4})
+    trajectory = Position({x0: 1, x1: 1, x2: 2, x3: 2, y0: 3, y1: 3, y2: 4})
+    benchmark(uncached_trajectory_matrix, cmf, trajectory, start)
 
 
 def test_trajectory_matrix_4f3_huge(benchmark):
     x0, x1, x2, x3 = sp.symbols("x:4")
     y0, y1, y2 = sp.symbols("y:3")
     cmf = pFq(4, 3, 1)
-    trajectory = {x0: -1, x1: 1, x2: 2, x3: -2, y0: 3, y1: 7, y2: 4}
+    trajectory = Position({x0: -1, x1: 1, x2: 2, x3: -2, y0: 3, y1: 7, y2: 4})
     start = trajectory
-    benchmark(CMF.trajectory_matrix, cmf, trajectory, start)
+    benchmark(uncached_trajectory_matrix, cmf, trajectory, start)
+
+
+def test_trajectory_matrix_adversarial_shards(benchmark):
+    cmf = pFq(4, 3, 1)
+    start = Position({x0: 1, x1: 1, x2: 1, x3: 1, y0: 2, y1: 2, y2: 3})
+    trajectory = Position({x0: 0, x1: 1, x2: 1, x3: 1, y0: 1, y1: 1, y2: 1})
+    benchmark(uncached_trajectory_matrix, cmf, trajectory, start)
 
 
 def test_walk_4f3(benchmark):
     x0, x1, x2, x3 = sp.symbols("x:4")
     y0, y1, y2 = sp.symbols("y:3")
     cmf = pFq(4, 3, 1)
-    start = {x0: 1, x1: 1, x2: 2, x3: 2, y0: 3, y1: 3, y2: 4}
-    trajectory = {x0: 1, x1: 1, x2: 2, x3: 2, y0: 3, y1: 3, y2: 4}
+    start = Position({x0: 1, x1: 1, x2: 2, x3: 2, y0: 3, y1: 3, y2: 4})
+    trajectory = Position({x0: 1, x1: 1, x2: 2, x3: 2, y0: 3, y1: 3, y2: 4})
     benchmark(CMF.walk, cmf, trajectory, 1000, start)
 
 
 def test_sub_cmf_3f3(benchmark):
     cmf = pFq(3, 3, -1)
     basis = {
-        a0: {x0: 0, x1: 1, x2: 0, y0: 0, y1: 1, y2: -1},
-        a1: {x0: 1, x1: 0, x2: 1, y0: 0, y1: 0, y2: 0},
-        b0: {x0: 0, x1: 0, x2: 0, y0: 0, y1: 1, y2: 1},
-        b1: {x0: 1, x1: 0, x2: 0, y0: 1, y1: 0, y2: 0},
+        a0: Position({x0: 0, x1: 1, x2: 0, y0: 0, y1: 1, y2: -1}),
+        a1: Position({x0: 1, x1: 0, x2: 1, y0: 0, y1: 0, y2: 0}),
+        b0: Position({x0: 0, x1: 0, x2: 0, y0: 0, y1: 1, y2: 1}),
+        b1: Position({x0: 1, x1: 0, x2: 0, y0: 1, y1: 0, y2: 0}),
     }
     benchmark(CMF.sub_cmf, cmf, basis)

--- a/ramanujantools/cmf/cmf_benchmark.py
+++ b/ramanujantools/cmf/cmf_benchmark.py
@@ -9,18 +9,17 @@ x0, x1, x2, x3 = sp.symbols("x:4")
 y0, y1, y2, y3 = sp.symbols("y:4")
 
 
-def uncached_trajectory_matrix(cmf, trajectory, start):
-    cmf._calculate_diagonal_matrix.cache_clear()
-    return cmf.trajectory_matrix(trajectory, start)
-
-
 def test_trajectory_matrix_simple(benchmark):
     from sympy.abc import x, y
 
     cmf = e()
     start = Position({x: 1, y: 1})
     trajectory = Position({x: 1, y: 1})
-    benchmark(uncached_trajectory_matrix, cmf, trajectory, start)
+    benchmark.pedantic(
+        cmf.trajectory_matrix,
+        setup=lambda: cmf._calculate_diagonal_matrix.cache_clear(),
+        args=(trajectory, start),
+    )
 
 
 def test_trajectory_matrix_2f2_euler(benchmark):
@@ -29,7 +28,11 @@ def test_trajectory_matrix_2f2_euler(benchmark):
     cmf = pFq(2, 2, -1)
     start = Position({x0: 1, x1: 1, y0: -1, y1: -1})
     trajectory = Position({x0: 1, x1: 1, y0: 0, y1: -1})
-    benchmark(uncached_trajectory_matrix, cmf, trajectory, start)
+    benchmark.pedantic(
+        cmf.trajectory_matrix,
+        setup=lambda: cmf._calculate_diagonal_matrix.cache_clear(),
+        args=(trajectory, start),
+    )
 
 
 def test_trajectory_matrix_2f2_deep(benchmark):
@@ -38,7 +41,11 @@ def test_trajectory_matrix_2f2_deep(benchmark):
     cmf = pFq(2, 2, -1)
     start = Position({x0: 1, x1: 1, y0: -1, y1: 1})
     trajectory = Position({x0: 12, x1: 13, y0: -14, y1: 20})
-    benchmark(uncached_trajectory_matrix, cmf, trajectory, start)
+    benchmark.pedantic(
+        cmf.trajectory_matrix,
+        setup=lambda: cmf._calculate_diagonal_matrix.cache_clear(),
+        args=(trajectory, start),
+    )
 
 
 def test_trajectory_matrix_3f2(benchmark):
@@ -47,7 +54,11 @@ def test_trajectory_matrix_3f2(benchmark):
     cmf = pFq(3, 2, 1)
     start = Position({x0: 2, x1: 2, x2: 2, y0: 4, y1: 4})
     trajectory = Position({x0: 5, x1: 5, x2: 5, y0: 10, y1: 10})
-    benchmark(uncached_trajectory_matrix, cmf, trajectory, start)
+    benchmark.pedantic(
+        cmf.trajectory_matrix,
+        setup=lambda: cmf._calculate_diagonal_matrix.cache_clear(),
+        args=(trajectory, start),
+    )
 
 
 def test_trajectory_matrix_3f2_rational(benchmark):
@@ -62,7 +73,11 @@ def test_trajectory_matrix_3f2_rational(benchmark):
         y1: sp.Rational(3, 2),
     }
     trajectory = Position({x0: 5, x1: 5, x2: 5, y0: 10, y1: 10})
-    benchmark(uncached_trajectory_matrix, cmf, trajectory, start)
+    benchmark.pedantic(
+        cmf.trajectory_matrix,
+        setup=lambda: cmf._calculate_diagonal_matrix.cache_clear(),
+        args=(trajectory, start),
+    )
 
 
 def test_trajectory_matrix_3f2_pertubated(benchmark):
@@ -71,7 +86,11 @@ def test_trajectory_matrix_3f2_pertubated(benchmark):
     cmf = pFq(3, 2, 1)
     start = Position({x0: 2, x1: 2, x2: 2, y0: 4, y1: 4})
     trajectory = Position({x0: 5, x1: 6, x2: 5, y0: 10, y1: 11})
-    benchmark(uncached_trajectory_matrix, cmf, trajectory, start)
+    benchmark.pedantic(
+        cmf.trajectory_matrix,
+        setup=lambda: cmf._calculate_diagonal_matrix.cache_clear(),
+        args=(trajectory, start),
+    )
 
 
 def test_trajectory_matrix_4f3(benchmark):
@@ -80,7 +99,11 @@ def test_trajectory_matrix_4f3(benchmark):
     cmf = pFq(4, 3, 1)
     start = Position({x0: 1, x1: 1, x2: 2, x3: 2, y0: 3, y1: 3, y2: 4})
     trajectory = Position({x0: 1, x1: 1, x2: 2, x3: 2, y0: 3, y1: 3, y2: 4})
-    benchmark(uncached_trajectory_matrix, cmf, trajectory, start)
+    benchmark.pedantic(
+        cmf.trajectory_matrix,
+        setup=lambda: cmf._calculate_diagonal_matrix.cache_clear(),
+        args=(trajectory, start),
+    )
 
 
 def test_trajectory_matrix_4f3_huge(benchmark):
@@ -89,14 +112,22 @@ def test_trajectory_matrix_4f3_huge(benchmark):
     cmf = pFq(4, 3, 1)
     trajectory = Position({x0: -1, x1: 1, x2: 2, x3: -2, y0: 3, y1: 7, y2: 4})
     start = trajectory
-    benchmark(uncached_trajectory_matrix, cmf, trajectory, start)
+    benchmark.pedantic(
+        cmf.trajectory_matrix,
+        setup=lambda: cmf._calculate_diagonal_matrix.cache_clear(),
+        args=(trajectory, start),
+    )
 
 
 def test_trajectory_matrix_adversarial_shards(benchmark):
     cmf = pFq(4, 3, 1)
     start = Position({x0: 1, x1: 1, x2: 1, x3: 1, y0: 2, y1: 2, y2: 3})
     trajectory = Position({x0: 0, x1: 1, x2: 1, x3: 1, y0: 1, y1: 1, y2: 1})
-    benchmark(uncached_trajectory_matrix, cmf, trajectory, start)
+    benchmark.pedantic(
+        cmf.trajectory_matrix,
+        setup=lambda: cmf._calculate_diagonal_matrix.cache_clear(),
+        args=(trajectory, start),
+    )
 
 
 def test_walk_4f3(benchmark):

--- a/ramanujantools/position.py
+++ b/ramanujantools/position.py
@@ -116,9 +116,9 @@ class Position(dict[sp.Symbol, sp.Expr]):
         return Position({key: self[key] for key in sorted(self.keys(), key=str)})
 
     def diagonal_decomposition(self) -> list[tuple[int, Position]]:
-        """
+        r"""
         Returns a list of diagonal positions and their multiplier $(m_i, \mathbf{d}_i)$,
-        such that the position is $\mathbf{p} = \sum_i m_i \cdot \mathbf{d}_i.
+        such that the position is $\mathbf{p} = \sum_i m_i \cdot \mathbf{d}_i$.
         """
         position = self
         retval = []

--- a/ramanujantools/position.py
+++ b/ramanujantools/position.py
@@ -115,6 +115,20 @@ class Position(dict[sp.Symbol, sp.Expr]):
     def sorted(self) -> Position:
         return Position({key: self[key] for key in sorted(self.keys(), key=str)})
 
+    def diagonal_decomposition(self) -> list[tuple[int, Position]]:
+        """
+        Returns a list of diagonal positions and their multiplier $(m_i, \mathbf{d}_i)$,
+        such that the position is $\mathbf{p} = \sum_i m_i \cdot \mathbf{d}_i.
+        """
+        position = self
+        retval = []
+        while position.longest() > 0:
+            depth = position.shortest()
+            diagonal = position.signs()
+            retval.append((depth, diagonal))
+            position -= depth * diagonal
+        return retval
+
     @staticmethod
     def from_list(values: list[sp.Expr], symbol: str) -> Position:
         """

--- a/ramanujantools/position.py
+++ b/ramanujantools/position.py
@@ -120,12 +120,16 @@ class Position(dict[sp.Symbol, sp.Expr]):
         Returns a list of diagonal positions and their multiplier $(m_i, \mathbf{d}_i)$,
         such that the position is $\mathbf{p} = \sum_i m_i \cdot \mathbf{d}_i$.
         """
+        if not self.is_integer():
+            raise ValueError(
+                "Position must be integer to perform diagonal decomposition."
+            )
         position = self.copy()
         retval = []
         while position.longest() > 0:
             depth = position.shortest()
             diagonal = position.signs()
-            retval.append((depth, diagonal))
+            retval.append((int(depth), diagonal))
             position -= depth * diagonal
         return retval
 

--- a/ramanujantools/position.py
+++ b/ramanujantools/position.py
@@ -120,7 +120,7 @@ class Position(dict[sp.Symbol, sp.Expr]):
         Returns a list of diagonal positions and their multiplier $(m_i, \mathbf{d}_i)$,
         such that the position is $\mathbf{p} = \sum_i m_i \cdot \mathbf{d}_i$.
         """
-        position = self
+        position = self.copy()
         retval = []
         while position.longest() > 0:
             depth = position.shortest()

--- a/ramanujantools/position_test.py
+++ b/ramanujantools/position_test.py
@@ -94,6 +94,18 @@ def test_free_symbols():
     assert {x, z} == Position({x: 1, y: z, z: x}).free_symbols()
 
 
+def test_diagonal_decomposition():
+    x0, x1, x2, x3, x4, x5, x6 = sp.symbols("x:7")
+    position = Position({x0: 0, x1: 2, x2: -2, x3: 2, x4: 4, x5: 7, x6: -8})
+    expected = [
+        (2, Position({x0: 0, x1: 1, x2: -1, x3: 1, x4: 1, x5: 1, x6: -1})),
+        (2, Position({x0: 0, x1: 0, x2: 0, x3: 0, x4: 1, x5: 1, x6: -1})),
+        (3, Position({x0: 0, x1: 0, x2: 0, x3: 0, x4: 0, x5: 1, x6: -1})),
+        (1, Position({x0: 0, x1: 0, x2: 0, x3: 0, x4: 0, x5: 0, x6: -1})),
+    ]
+    assert expected == position.diagonal_decomposition()
+
+
 def test_from_list():
     z0, z1, z2, z3 = sp.symbols("z:4")
     expected = Position({z0: 9, z1: 8, z2: 7, z3: 6})


### PR DESCRIPTION
Change the heuristic in trajectory matrix, both when selecting diagonals and when selecting the multiplication order to calculate a diagonal matrix, to a reversed-order DFS.

Many trajectory matrix calculations were getting stuck and the random order allows to pick a completely different branch in the "DFS" we had previously with the backtracking, allowing to instantly jump to a completely different path which is less likely to hit the same shard.